### PR TITLE
Allow qemu to use bridges on graham

### DIFF
--- a/hosts/graham.nix
+++ b/hosts/graham.nix
@@ -25,5 +25,13 @@
   # IPMI/BMC:
   # - d0:8e:79:ba:02:1a
 
+  # Allow qemu to access bridges
+  environment.etc."qemu/bridge.conf" = {
+    user = "root";
+    group = "qemu";
+    mode = "640";
+    text = "allow all";
+  };
+
   system.stateVersion = "21.05";
 }

--- a/hosts/graham.nix
+++ b/hosts/graham.nix
@@ -33,5 +33,14 @@
     text = "allow all";
   };
 
+  # Don't manage tap devices with systemd-networkd
+  systemd.network.networks."06-tap".extraConfig = ''
+    [Match]
+    Name = tap*
+
+    [Link]
+    Unmanaged = yes
+  '';
+
   system.stateVersion = "21.05";
 }


### PR DESCRIPTION
This configuration is needed to use bridge devices from qemu. For example:

```
# create a virtual bridge
$ sudo brctl addbr virbr0
$ sudo ip a a  172.44.0.1/24 dev virbr0
$ sudo ip l set dev virbr0 up

# use bridge from qemu
% qemu-system-x86_64  \
    -netdev bridge,id=en0,br=virbr0 \
    -device virtio-net-pci,netdev=en0,id=nic1 \
[...]
```

When using a bridge, qemu creates a tap device. 6d660cd prevents systemd-networkd manage tap device. Otherwise, systemd-networkd assigns an IP address to a tap device and it will conflict with a bridge setting.

Tested on graham. Maybe this configuration can be defined in modules/netowork.nix to apply to all servers.