### PR TITLE
fpga: change path to xilinx tools

### DIFF
--- a/modules/xilinx.nix
+++ b/modules/xilinx.nix
@@ -19,9 +19,10 @@ in {
   ];
 
   boot.kernelPackages = pkgs.linuxPackages_5_10;
-  boot.extraModulePackages = [
-    xrt-drivers
-  ];
+  # The kernel drivers are not required this time. 
+  # boot.extraModulePackages = [
+  #   xrt-drivers
+  # ];
 
   hardware.opengl.extraPackages = [
     packages.xrt

--- a/pkgs/xilinx/fhs-env.nix
+++ b/pkgs/xilinx/fhs-env.nix
@@ -48,6 +48,6 @@ buildFHSUserEnv {
     ];
   multiPkgs = null;
   profile = ''
-    source /opt/xilinx/Vitis/*/settings64.sh
+    source /share/xilinx/Vitis/2021.2/settings64.sh
   '';
 }


### PR DESCRIPTION
I successfully installed and tested Xilinx tools w/ `xilinx-shell` on Ryan. They should work on the other machines where our nfs is mounted. 