### PR TITLE
Linux 5.15 ioregionfd

### DIFF
--- a/hosts/river.nix
+++ b/hosts/river.nix
@@ -8,7 +8,7 @@
     ../modules/nfs/client.nix
     ../modules/dax.nix # just to disable PM as RAM
     ../modules/dpdk.nix
-    #../modules/linux-ioregionfd.nix
+    ../modules/linux-ioregionfd.nix
   ];
 
   boot.hugepages.size = "1GB";

--- a/modules/linux-ioregionfd.nix
+++ b/modules/linux-ioregionfd.nix
@@ -1,5 +1,5 @@
 { pkgs, lib, ...}: let 
-  linux_ioregionfd = pkgs.callPackage ../pkgs/kernels/linux-ioregionfd-5.14.nix { };
+  linux_ioregionfd = pkgs.callPackage ../pkgs/kernels/linux-ioregionfd-5.15.nix { };
   linuxPackages_ioregionfd = pkgs.recurseIntoAttrs 
     (pkgs.linuxPackagesFor linux_ioregionfd);
 in {

--- a/pkgs/kernels/linux-ioregionfd-5.15.nix
+++ b/pkgs/kernels/linux-ioregionfd-5.15.nix
@@ -1,0 +1,25 @@
+{ buildLinux, fetchFromGitHub, linuxPackages_5_15, fetchurl, modDirVersionArg ? null, ... }@args:
+
+buildLinux (args // rec {
+  version = "5.15";
+  modDirVersion = if (modDirVersionArg == null) then
+    builtins.replaceStrings [ "-" ] [ ".0-" ] version
+      else
+    modDirVersionArg;
+  src = fetchFromGitHub {
+    owner = "vmuxIO";
+    repo = "linux";
+    rev = "4442a5e9a8f2f31646011c75dfcbe74cc699092f"; # branch ioregion-5.15
+    sha256 = "sha256-PfjtFwvVMBks+5JWwsIX5jqhWgso13rscAqQ1C1ONfg=";
+  };
+
+  kernelPatches = [{
+    name = "enable-kvm-ioregion";
+    patch = null;
+    extraConfig = ''
+      KVM_IOREGION y
+    '';
+  }]; # ++ linuxPackages_5_15.kernel.kernelPatches;
+  extraMeta.branch = "5.15";
+  ignoreConfigErrors = true;
+} // (args.argsOverride or { }))

--- a/pkgs/kernels/linux-ioregionfd-5.15.nix
+++ b/pkgs/kernels/linux-ioregionfd-5.15.nix
@@ -2,12 +2,12 @@
 
 buildLinux (args // rec {
   version = "5.15";
-  modDirVersion = "5.15.0";
+  modDirVersion = "5.15.84";
   src = fetchFromGitHub {
-    owner = "vmuxIO";
+    owner = "gierens";
     repo = "linux";
-    rev = "4442a5e9a8f2f31646011c75dfcbe74cc699092f"; # branch ioregion-5.15
-    sha256 = "sha256-PfjtFwvVMBks+5JWwsIX5jqhWgso13rscAqQ1C1ONfg=";
+    rev = "669ce309ca5572e66ab5a2df30207c7a48cc75f3"; # branch v5.15.84-ioregionfd
+    sha256 = "sha256-HrfndxdkIto6NrYKcX0oI4XQvHO5axsrWrV15UYm2ho=";
   };
 
   kernelPatches = [{

--- a/pkgs/kernels/linux-ioregionfd-5.15.nix
+++ b/pkgs/kernels/linux-ioregionfd-5.15.nix
@@ -2,10 +2,7 @@
 
 buildLinux (args // rec {
   version = "5.15";
-  modDirVersion = if (modDirVersionArg == null) then
-    builtins.replaceStrings [ "-" ] [ ".0-" ] version
-      else
-    modDirVersionArg;
+  modDirVersion = "5.15.0";
   src = fetchFromGitHub {
     owner = "vmuxIO";
     repo = "linux";


### PR DESCRIPTION
This adds the ioregionfd kernel package for 5.15 (`pkgs/kernels/linux-ioregionfd-5.15.nix`), updates the the ioregionfd module (`modules/linux-ioregionfd.nix`) to point to the new package, and adds it back to river's imports (`hosts/river.nix`).