### PR TITLE
Add iommu-intel module to river's config

### DIFF
--- a/hosts/river.nix
+++ b/hosts/river.nix
@@ -4,6 +4,7 @@
     ../modules/nfs/client.nix
     ../modules/dax.nix # just to disable PM as RAM
     ../modules/dpdk.nix
+    ../modules/vfio/iommu-intel.nix
     ../modules/linux-ioregionfd.nix
   ];
 


### PR DESCRIPTION
We need this for vfio/vmux tests on river.