### PR TITLE
drop legacy mountpoint from /tmp

### DIFF
--- a/modules/disko-zfs.nix
+++ b/modules/disko-zfs.nix
@@ -65,7 +65,6 @@
               type = "zfs_fs";
               mountpoint = "/tmp";
               options.sync = "disabled";
-              options."mountpoint" = lib.mkIf config.disko.zfs.legacyMounts.enable "legacy";
             };
           };
         };


### PR DESCRIPTION

dan & astrid already migrated this.