### PR TITLE
[WIP/Do Not Merge] snp: kernel update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1722192762,
-        "narHash": "sha256-dTe9kdpNZ8AyqaUST+1unWLWyv6fMZDuelipvORBSQ0=",
+        "lastModified": 1722175292,
+        "narHash": "sha256-QQPnU2L3TqI2XVpp7ROWSyr/+QcfX9JlC0y+WbSLlOs=",
         "owner": "TUM-DSE",
         "repo": "nixpkgs",
-        "rev": "ba62b9cdc65eccf400d5031651fd0d0f2edbfe90",
+        "rev": "0ca8982ba97b2d48bf757b80c723badb8797d969",
         "type": "github"
       },
       "original": {

--- a/pkgs/kernels/linux-sev-snp.nix
+++ b/pkgs/kernels/linux-sev-snp.nix
@@ -115,7 +115,7 @@ let
     extraPatches = [ ];
   };
 
-  snp_latest = {
+  snp_6_9 = {
     owner = "mmisono";
     repo = "linux";
     # branch: snp-host-latest-20240514
@@ -123,6 +123,17 @@ let
     sha256 = "sha256-ZEfGa2dbHlXWPbEzUmHrWTIifVt4PtkM+w1cHTzt7xw=";
     version = "6.9";
     modDirVersion = "6.9.0-rc7";
+    extraPatches = [ ];
+  };
+
+  snp_latest = {
+    owner = "mmisono";
+    repo = "linux";
+    # branch: kvm-next-20240717
+    rev = "332d2c1d713e232e163386c35a3ba0c1b90df83f";
+    sha256 = "sha256-bkyJzgh8JU8uN7hF4HK0bUCQTaViDZcoWbH5pSM2v1Y=";
+    version = "6.10";
+    modDirVersion = "6.10.0-rc7";
     extraPatches = [ ];
   };
 in


### PR DESCRIPTION
The 6.9 kernel has some weird performance issues on SNP.
This is the current latest kvm-next kernel (https://github.com/mmisono/linux/tree/kvm-next-20240717). 

However, currently, this does not compile due to ZFS

```
       > checking whether blk_queue_max_hw_sectors() is available... configure: error:
       >     *** None of the expected "blk_queue_max_hw_sectors" interfaces were detected.
       >  *** This may be because your kernel version is newer than what is
       >      *** supported, or you are using a patched custom kernel with
       >   *** incompatible modifications.
       >        ***
       >    *** ZFS Version: zfs-2.2.4-1
       >   *** Compatible Kernels: 3.10 - 6.8
       >
```

TODO
- [ ] Fix the ZFS issue
- [ ] Confirm if a SNP VM boots