### PR TITLE
Add user for cgo25 artifact evaluation

### DIFF
--- a/modules/users/reviewers.nix
+++ b/modules/users/reviewers.nix
@@ -1,7 +1,21 @@
+let cgoPixel8Keys = [
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOPHHU+BO8E/+Mn98QFbkbz9mYm5wNUTBYGOO8EMGg7o pixel8"
+];
+in
 {
   # Please use a uid in the range between 4000-5000
   # You can set `users.users.<name>.allowedHosts` to restrict access to certain machines.
-  users.users = { };
+  users.users = {
+    # Pixel 8 connects to graham and sets up port forwarding to allow access for reviewers 
+    cgoPixel8 = {
+      isNormalUser = true;
+      home = "/home/cgoPixel8";
+      shell = "/run/current-system/sw/bin/bash";
+      uid = 4005;
+      allowedHosts = ["graham"];
+      openssh.authorizedKeys.keys = cgoPixel8Keys;
+    };
+  };
 
   # DANGER ZONE!
   # Make sure all data is backed up before adding user names here. This will


### PR DESCRIPTION
This adds a user that is used by the Pixel 8 to connect to graham. There, it sets up a port forwarding so reviewers can connect from Graham to the Pixel 8.