### PR TITLE
Exclude google traces for Funky from nfs backup

### DIFF
--- a/modules/nfs/server.nix
+++ b/modules/nfs/server.nix
@@ -151,6 +151,8 @@
         # vm images
         "/export/share/cmainas/**/*.img"
         "/export/share/martinL/**/*.img"
+        # large google traces
+        "/export/share/cmainas/traces"
       ];
       encryption = {
         mode = "repokey";


### PR DESCRIPTION
We will use some Google tracs for Funky resubmission. The tracea ar hundrends of Gbs and it will extremely slow down any back up operations. Also, there is no need for backing them up. Therefore, we exclude them from the nfs back ups.