### PR TITLE
also create scratch space for root user

### DIFF
--- a/modules/nfs/client.nix
+++ b/modules/nfs/client.nix
@@ -38,6 +38,13 @@
 in {
   imports = [ ./. ];
 
+  environment.sessionVariables = {
+    # Since nix 2.20, nix stores a significant amount of data in $XDG_CACHE_HOME/nix because of the tarball cache.
+    XDG_CACHE_HOME = ["/scratch/$USER/.cache"];
+    # This fixes user profile generation i.e. used by home-manager
+    XDG_STATE_HOME = ["/scratch/$USER/.local/share"];
+  };
+
   # How should we mount NFS?
 
   # This (using systemd.mount) fails sometimes, because network isn't ready yet:

--- a/modules/scratch-space.nix
+++ b/modules/scratch-space.nix
@@ -12,7 +12,7 @@
   #           of re-formatted in order to have consistent measurement results
   systemd.tmpfiles.rules =
     let
-      loginUsers = lib.filterAttrs (_n: v: v.isNormalUser) config.users.users;
+      loginUsers = lib.filterAttrs (_n: v: v.isNormalUser || v.name == "root") config.users.users;
     in
     (lib.mapAttrsToList (n: _v: "d /scratch/${n} 0755 ${n} users -") loginUsers)
     ++ (builtins.map (n: "R /scratch/${n} - - - - -") config.users.deletedUsers)


### PR DESCRIPTION

This is now needed because we moved XDG_CACHE_HOME