### PR TITLE
Add musl-morello

### DIFF
--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -37,6 +37,8 @@
       linux-morello = pkgs.callPackage ./kernels/linux-morello.nix {
         inherit (self.packages.aarch64-linux) clang-morello bintools-morello clang-morello-unwrapped;
       };
+      musl-morello-purecap = pkgs.callPackage ./musl-morello-purecap { inherit (self.packages.aarch64-linux) llvm-morello-purecap; };
+      llvm-morello-purecap = pkgs.callPackage ./llvm-morello-purecap { };
     };
 
   # packages for many targets:

--- a/pkgs/llvm-morello-purecap/default.nix
+++ b/pkgs/llvm-morello-purecap/default.nix
@@ -1,0 +1,46 @@
+{
+  stdenv,
+  zlib,
+  fetchurl,
+  autoPatchelfHook,
+  llvmPackages_14,
+}:
+stdenv.mkDerivation {
+  name = "llvm-morello-purecap";
+  src = fetchurl {
+    url = "https://git.morello-project.org/morello/llvm-project-releases/-/archive/morello/linux-aarch64-release-1.8/llvm-project-releases-morello-linux-aarch64-release-1.8.tar.gz";
+    sha256 = "sha256-6kPG5y6wDFFiI+x/MYzdF6Rh6uSiclCz2nTN8OOQOQw=";
+    downloadToTemp = true;
+  };
+
+  installPhase = ''
+    cp -r ./ $out/
+  '';
+
+  buildInputs = [
+    zlib
+    stdenv.cc.cc
+  ];
+  nativeBuildInputs = [ autoPatchelfHook ];
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/clang --version
+    $out/bin/ld.lld --version
+  '';
+  passthru.isClang = true;
+  passthru.hardeningUnsupportedFlagsByTargetPlatform =
+    targetPlatform:
+    (
+      if builtins.hasAttr "hardeningUnsupportedFlagsByTargetPlatform" llvmPackages_14.clang-unwrapped then
+        llvmPackages_14.clang-unwrapped.hardeningUnsupportedFlagsByTargetPlatform targetPlatform
+      else
+        [ ]
+    )
+    ++ [ "strictoverflow" ];
+
+  meta = {
+    description = "Morello build toolchain";
+    platforms = [ "aarch64-linux" ];
+  };
+}
+

--- a/pkgs/musl-morello-purecap/default.nix
+++ b/pkgs/musl-morello-purecap/default.nix
@@ -1,0 +1,26 @@
+{
+  stdenv,
+  llvm-morello-purecap,
+  fetchgit,
+}:
+stdenv.mkDerivation {
+  name = "musl-morello-purecap";
+  src = fetchgit {
+    url = "https://git.morello-project.org/morello/musl-libc.git";
+    rev = "64ae92a5460476c13c8b73919fdbc3a1f7bbaeb8";
+    sha256 = "sha256-mz9CZR7UvN9A+IRaaloGFVLSa/X2e7VqCXG5s5BpKSg=";
+  };
+  buildInputs = [
+    llvm-morello-purecap
+  ];
+  configurePhase = ''
+    CC=${llvm-morello-purecap}/bin/clang ./configure --disable-shared --enable-morello --enable-wrapper=clang --prefix=$out --target=aarch64-linux-musl_purecap
+  '';
+
+  patchPhase = "";
+
+  meta = {
+    description = "Morello musl libc";
+    platforms = [ "aarch64-linux" ];
+  };
+}


### PR DESCRIPTION
This builds a toolchain that can be used for purecap binaries. Currently, it only supports statically linked binaries.

`flake.nix`:

```
{
  description = "A generic development shell";

  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
    doctor-cluster.url = "github:TUM-DSE/doctor-cluster-config";
    doctor-cluster.inputs.nixpkgs.follows = "nixpkgs";
  };

  outputs =
    { nixpkgs, doctor-cluster, ... }:
    let
      system = "aarch64-linux";
      pkgs = nixpkgs.legacyPackages.${system};
      doctorPackages = doctor-cluster.packages.${system};
    in
    {
      devShells.${system} = {
        default = pkgs.mkShell {
          nativeBuildInputs = with pkgs; [
            doctorPackages.llvm-morello-purecap
            doctorPackages.musl-morello-purecap
          ];
          buildInputs = with pkgs; [ ];

          MUSL_PATH = "${doctorPackages.musl-morello-purecap}";
        };
      };
    };
}
```

## Example

`hello_world.c`:
```
#include <stdio.h>

int main() {
  printf("Hello, world: %lu\n", sizeof(void*));
}
```

```shell
clang --target=aarch64-unknown-linux-musl_purecap \
  -mabi=purecap \
  -march=morello \
  -fuse-ld=lld \
  -nostdinc \
  --sysroot $MUSL_PATH/ \
  -isystem $MUSL_PATH/include \
  -L$MUSL_PATH/lib \
  -static \
  hello_world.c \
  -o hello
./hello
```