### PR TITLE
New TDX Kernel on Martha

### DIFF
--- a/hosts/martha.nix
+++ b/hosts/martha.nix
@@ -5,7 +5,7 @@
     ../modules/nfs/client.nix
     ../modules/disko-zfs.nix
 
-    ../modules/vfio/iommu-amd.nix
+    ../modules/vfio/iommu-intel.nix
     ../modules/dpdk.nix
   ];
 

--- a/hosts/martha.nix
+++ b/hosts/martha.nix
@@ -4,6 +4,7 @@
     ../modules/hardware/poweredge-r770.nix
     ../modules/nfs/client.nix
     ../modules/disko-zfs.nix
+    ../modules/intel_tdx.nix
 
     ../modules/vfio/iommu-intel.nix
     ../modules/dpdk.nix

--- a/pkgs/kernels/linux-tdx.nix
+++ b/pkgs/kernels/linux-tdx.nix
@@ -30,11 +30,12 @@ let
               KVM_MMU_PRIVATE y
             '';
           }
-          {
-            name = "bug_func export";
-            patch = ./zfs-tdx.patch;
-            extraConfig = '''';
-          }
+          # NOTE: only needed prior to 6.9
+          # {
+          #   name = "bug_func export";
+          #   patch = ./zfs-tdx.patch;
+          #   extraConfig = '''';
+          # }
         ] ++ extraPatches;
         extraMeta.branch = version;
         ignoreConfigErrors = true;
@@ -49,6 +50,15 @@ let
     version = "6.8";
     modDirVersion = "6.8.0-rc1";
   };
+  tdx_canonical_6_11_0_1006_6 = {
+    owner = "gierens";
+    repo = "linux-tdx-canonical";
+    # branch: main
+    rev = "414aea81b805c91b61a65652605a8b4360eb22a1";
+    sha256 = "sha256-xmUGhyhfLEvaGC7LtogVXcpSK2VL0jYlj1kvW2lyHQU=";
+    version = "6.11";
+    modDirVersion = "6.11.0";
+  };
 in
 # change here to change kernel
-buildKernel tdx_kvm_upstream_next_20240122
+buildKernel tdx_canonical_6_11_0_1006_6


### PR DESCRIPTION
This updates the TDX package to build the new 6.11 TDX patched
kernel provided by Canonical necessary to run TDX VMs on Xeon 6
CPUs. It adds that config to martha, and fixes a typo in the
recently added IOMMU config of it.

I already build and deployed this manually on ian and martha, and
made sure it boots and that TDX VMs work now on both servers.
