### PR TITLE
host/jamie: disabled nvidia configuration

### DIFF
--- a/hosts/jamie.nix
+++ b/hosts/jamie.nix
@@ -3,7 +3,6 @@
   imports = [
     ../modules/hardware/poweredge7625.nix
     ../modules/nfs/client.nix
-    ../modules/nvidia.nix
     ../modules/amd_sev_snp.nix
   ];
 


### PR DESCRIPTION
When the NVIDIA drivers are loaded on the host, we can't configure the H100 for CC