### PR TITLE
flake: update buildbot-nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739067083,
-        "narHash": "sha256-35u+eOnTiK2YAMUwMcgg7wbnDKjvzMbNBJOlTcqwvG0=",
+        "lastModified": 1751515480,
+        "narHash": "sha256-vCYcc/b8WizF6vnjuRVxSiU8hy9L3vOTWDVKpWM7xRE=",
         "owner": "nix-community",
         "repo": "buildbot-nix",
-        "rev": "ccaecb0ec9ff6db341f622b0f2a54b562e0f1c73",
+        "rev": "47ad4c7afb169df6f9d48d0df3d7e2f71d9ddd8f",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738237977,
-        "narHash": "sha256-oJN/yvRL7G0WlR/hTkQIjFbPkzCV+sFnNB/38Tb9RL4=",
+        "lastModified": 1748000383,
+        "narHash": "sha256-EaAJhwfJGBncgIV/0NlJviid2DP93cTMc9h0q6P6xXk=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "6d1b6d5d59758b4f5f05745f774fc13cdc59da43",
+        "rev": "231726642197817d20310b9d39dd4afb9e899489",
         "type": "github"
       },
       "original": {
@@ -270,10 +270,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745385072,
-        "narHash": "sha256-geZyeQp56HeUaMbhPUVpuN58QfJ94s0jLOUoNf/jUlg=",
+        "lastModified": 1751461431,
+        "narHash": "sha256-wzJps3ZoaLMYYW7tCIhw1a625/kYuJ9s0MbkCxBi3VE=",
         "ref": "nixos-unstable-small",
-        "rev": "6722b86722d71dbf45591685d355664645912388",
+        "rev": "12d516726903aae3c89fe2b6b65a6880c7101c25",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"


### PR DESCRIPTION
## Summary
- Updates the buildbot-nix flake input to the latest version

## Changes
```diff
+        "lastModified": 1751219269,
+        "narHash": "sha256-NOCIoQgKPL9yNggvw3wpVYkAQa5FQwDAvIFb67GOP9Q=",
+        "rev": "b915f4993ec5312dbc35bd915b7e74b9aecfbf7d",
+        "lastModified": 1748000383,
+        "narHash": "sha256-EaAJhwfJGBncgIV/0NlJviid2DP93cTMc9h0q6P6xXk=",
+        "rev": "231726642197817d20310b9d39dd4afb9e899489",
+        "lastModified": 1751143112,
+        "narHash": "sha256-j7e3EHnAv4FCWn3iQCyQbxBpaAKbgYQW8lLHDTTVJgU=",
+        "rev": "340deb49293d447dba3038321be090a4bec9981c",
```

## Test plan
- [ ] Build configurations pass
- [ ] No regressions in functionality