### PR TITLE
flake: update home-manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736373539,
-        "narHash": "sha256-dinzAqCjenWDxuy+MqUQq0I4zUSfaCvN9rzuCmgMZJY=",
+        "lastModified": 1747688870,
+        "narHash": "sha256-ypL9WAZfmJr5V70jEVzqGjjQzF0uCkz+AFQF7n9NmNc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd65bc3cde04c16755955630b344bc9e35272c56",
+        "rev": "d5f1f641b289553927b3801580598d200a501863",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates the home-manager flake input to the latest version

## Changes
```diff
+        "lastModified": 1747688870,
+        "narHash": "sha256-ypL9WAZfmJr5V70jEVzqGjjQzF0uCkz+AFQF7n9NmNc=",
+        "rev": "d5f1f641b289553927b3801580598d200a501863",
```

## Test plan
- [ ] Build configurations pass
- [ ] No regressions in functionality