### PR TITLE
flake: update jetpack-nixos

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -180,10 +180,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1744294216,
-        "narHash": "sha256-CHMDNDd2JAOUNs+wa+0C5rxu4Fa+tWiP53fAdaIe8d4=",
+        "lastModified": 1745928536,
+        "narHash": "sha256-aXGMduDFut5l7wni16xMjGXKaAQqNoSbPvzkxeEGG10=",
         "ref": "final-stretch",
-        "rev": "3c874eb1c71f658218aeba26d2b5cf3e512022c0",
+        "rev": "9c89649ff732c195962c7928645c5273d6125834",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/TUM-DSE/jetpack-nixos.git"


### PR DESCRIPTION
## Summary
- Updates the jetpack-nixos flake input to the latest version

## Changes
```diff
+        "lastModified": 1745928536,
+        "narHash": "sha256-aXGMduDFut5l7wni16xMjGXKaAQqNoSbPvzkxeEGG10=",
+        "rev": "9c89649ff732c195962c7928645c5273d6125834",
```

## Test plan
- [ ] Build configurations pass
- [ ] No regressions in functionality