### PR TITLE
flake: update nix-index-database

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739071773,
-        "narHash": "sha256-/Ak+Quinhmdxa9m3shjm4lwwwqmzG8zzGhhhhgR1k9I=",
+        "lastModified": 1751170039,
+        "narHash": "sha256-3EKpUmyGmHYA/RuhZjINTZPU+OFWko0eDwazUOW64nw=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "895d81b6228bbd50a6ef22f5a58a504ca99763ea",
+        "rev": "9c932ae632d6b5150515e5749b198c175d8565db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates the nix-index-database flake input to the latest version

## Changes
```diff
+        "lastModified": 1751170039,
+        "narHash": "sha256-3EKpUmyGmHYA/RuhZjINTZPU+OFWko0eDwazUOW64nw=",
+        "rev": "9c932ae632d6b5150515e5749b198c175d8565db",
```

## Test plan
- [ ] Build configurations pass
- [ ] No regressions in functionality