### PR TITLE
flake: update nixos-generators

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737057290,
-        "narHash": "sha256-3Pe0yKlCc7EOeq1X/aJVDH0CtNL+tIBm49vpepwL1MQ=",
+        "lastModified": 1747663185,
+        "narHash": "sha256-Obh50J+O9jhUM/FgXtI3he/QRNiV9+J53+l+RlKSaAk=",
         "owner": "nix-community",
         "repo": "nixos-generators",
-        "rev": "d002ce9b6e7eb467cd1c6bb9aef9c35d191b5453",
+        "rev": "ee07ba0d36c38e9915c55d2ac5a8fb0f05f2afcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates the nixos-generators flake input to the latest version

## Changes
```diff
+        "lastModified": 1747663185,
+        "narHash": "sha256-Obh50J+O9jhUM/FgXtI3he/QRNiV9+J53+l+RlKSaAk=",
+        "rev": "ee07ba0d36c38e9915c55d2ac5a8fb0f05f2afcc",
```

## Test plan
- [ ] Build configurations pass
- [ ] No regressions in functionality