### PR TITLE
flake: update retiolum

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -304,11 +304,11 @@
     },
     "retiolum": {
       "locked": {
-        "lastModified": 1737987273,
-        "narHash": "sha256-WQCLoDbthUO5PcdYDBxZZQgpQbEXab50EcwChkukxN4=",
+        "lastModified": 1751217716,
+        "narHash": "sha256-RMYMAzzos+aNtF/bKZDduOMFIdmqcTbjBjTiGJZiSl0=",
         "owner": "Mic92",
         "repo": "retiolum",
-        "rev": "514fe96610f745435b89355822691b1961dc4857",
+        "rev": "39440d8e2115c349f175461e584e52f4e2bac330",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates the retiolum flake input to the latest version

## Changes
```diff
+        "lastModified": 1751217716,
+        "narHash": "sha256-RMYMAzzos+aNtF/bKZDduOMFIdmqcTbjBjTiGJZiSl0=",
+        "rev": "39440d8e2115c349f175461e584e52f4e2bac330",
```

## Test plan
- [ ] Build configurations pass
- [ ] No regressions in functionality