### PR TITLE
flake: update sops-nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -361,11 +361,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738291974,
-        "narHash": "sha256-wkwYJc8cKmmQWUloyS9KwttBnja2ONRuJQDEsmef320=",
+        "lastModified": 1750119275,
+        "narHash": "sha256-Rr7Pooz9zQbhdVxux16h7URa6mA80Pb/G07T4lHvh0M=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4c1251904d8a08c86ac6bc0d72cc09975e89aef7",
+        "rev": "77c423a03b9b2b79709ea2cb63336312e78b72e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates the sops-nix flake input to the latest version

## Changes
```diff
+        "lastModified": 1750119275,
+        "narHash": "sha256-Rr7Pooz9zQbhdVxux16h7URa6mA80Pb/G07T4lHvh0M=",
+        "rev": "77c423a03b9b2b79709ea2cb63336312e78b72e2",
```

## Test plan
- [ ] Build configurations pass
- [ ] No regressions in functionality