### PR TITLE
flake: update srvos

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -381,11 +381,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738803210,
-        "narHash": "sha256-28/+C9I0z/R1Z64rTn25biIHZ9QEt4rlGr7tYb0186A=",
+        "lastModified": 1750907330,
+        "narHash": "sha256-rXA4RdUfZxBmy3RZ8TiP9ITuGwLGBWlyP16dN6ILS6M=",
         "owner": "numtide",
         "repo": "srvos",
-        "rev": "9c9423e8f947af2ec80b1d9da677e1dd166e3377",
+        "rev": "3af451e7eb42df68fc06b689da4f4ca7198eed5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates the srvos flake input to the latest version

## Changes
```diff
+        "lastModified": 1750907330,
+        "narHash": "sha256-rXA4RdUfZxBmy3RZ8TiP9ITuGwLGBWlyP16dN6ILS6M=",
+        "rev": "3af451e7eb42df68fc06b689da4f4ca7198eed5e",
```

## Test plan
- [ ] Build configurations pass
- [ ] No regressions in functionality