### PR TITLE
Ian update

### DIFF
--- a/hosts/ian.nix
+++ b/hosts/ian.nix
@@ -2,8 +2,8 @@
   imports = [
     ../modules/hardware/poweredge-r760.nix
     ../modules/nfs/client.nix
-    ../modules/linux-uintr.nix
-    #../modules/intel_tdx.nix
+    #../modules/linux-uintr.nix
+    ../modules/intel_tdx.nix
   ];
 
   disko.rootDisk = "/dev/disk/by-id/nvme-SAMSUNG_MZQL23T8HCLS-00A07_S64HNS0W800690";

--- a/pkgs/kernels/linux-tdx.nix
+++ b/pkgs/kernels/linux-tdx.nix
@@ -28,6 +28,8 @@ let
               CRASH_DUMP n
               INTEL_TDX_HOST y
               KVM_MMU_PRIVATE y
+              DRM n
+              IIO n
             '';
           }
           # NOTE: only needed prior to 6.9

--- a/pkgs/kernels/linux-tdx.nix
+++ b/pkgs/kernels/linux-tdx.nix
@@ -28,7 +28,7 @@ let
               CRASH_DUMP n
               INTEL_TDX_HOST y
               KVM_MMU_PRIVATE y
-              DRM n
+              DRM_AMDGPU n
               IIO n
             '';
           }


### PR DESCRIPTION
To compile TDX kernel with the current NixOS (25.04), I have to disable amdgpu and IIO config for some reason:

```
              DRM_AMDGPU n
              IIO n
```

This compiles and boots, but now IPMI virtual console does not work (NO SIGNAL).