### PR TITLE
eliza: nvidia: enable nvidia-container-runtime

### DIFF
--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -1,0 +1,50 @@
+# GPUs
+
+## GPU servers
+- jamie (AMD EPYC)
+    - H100 (80GB, CC support)
+- eliza (Ampare aarch64)
+    - A40 (48GB)
+
+## Quick test
+```
+nvidia-smi
+docker run --rm -it --device=nvidia.com/gpu=all ubuntu:latest nvidia-smi
+```
+
+## Cuda docker
+- Check supported cuda version (it depends on the driver version)
+```
+nvidia-smi # this shows driver and cuda version
+```
+
+- Run containers
+```
+docker pull nvidia/cuda:12.8.0-cudnn-devel-ubuntu24.04
+docker run -it --name dev-cuda12.8 -v /scratch/$USER/work:/work -device=nvidia.com/gpu=all nvidia/cuda:12.8.0-cudnn-devel-ubuntu24.04
+```
+
+- Test (in the container)
+```
+cd /work/
+apt update
+apt install git cmake
+git clone https://github.com/NVIDIA/cuda-samples
+cd cuda-samples
+git checkout -b v12.8 tags/v12.8
+mkdir build
+cd build
+cmake ..
+make -j$(nproc)
+./Samples/1_Utilities/deviceQuery/deviceQuery
+```
+
+- llama.cpp
+```
+git clone https://github.com/ggml-org/llama.cpp/
+cd llama.cpp
+apt install curl libcurl4-openssl-dev
+cmake -B build -DGGML_CUDA=ON
+cmake --build build --config Release -j $(nproc)
+LLAMA_CACHE=/work/models ./build/bin/llama-cli -hf ggml-org/gemma-3-1b-it-GGUF --gpu-layers -1
+```

--- a/hosts/eliza.nix
+++ b/hosts/eliza.nix
@@ -2,11 +2,16 @@
   imports = [
     ../modules/hardware/supermicro-ARS-211M-NR.nix
     ../modules/nfs/client.nix
-    ../modules/nvidia-aarch64.nix
+    ../modules/nvidia.nix
     ../modules/disko-zfs.nix
   ];
 
   networking.hostName = "eliza";
+
+  boot.kernelParams = [
+    # NVIDIA A40 GPU had a bus error once. Set this as potential workaround.
+    "pcie_aspm=off"
+  ];
 
   disko.rootDisk = "/dev/disk/by-id/nvme-SAMSUNG_MZQL23T8HCLS-00A07_S64HNN0XA20382";
 

--- a/modules/nvidia-aarch64.nix
+++ b/modules/nvidia-aarch64.nix
@@ -1,7 +1,0 @@
-{ config, lib, ... }:
-{
-  hardware.graphics.enable = true;
-  systemd.services.nvidia-fabricmanager.enable = lib.mkForce false;
-
-  virtualisation.docker.enable = true;
-}

--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -1,6 +1,13 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 {
-  hardware.graphics.enable = true;
+
+  hardware.graphics =  {
+    enable = true;
+  }
+  // lib.optionalAttrs(pkgs.stdenv.hostPlatform.isx86_64) {
+    enable32Bit = true;
+  };
+
   # Switching from datacenter driver to production driver for kernel 6.15 compatibility
   # The production driver (570.153.02) includes patches for kernel 6.15 support
   # while dc_565 (565.57.01) does not support kernels newer than 6.13
@@ -14,5 +21,4 @@
 
   virtualisation.docker.enable = true;
   hardware.nvidia-container-toolkit.enable = true;
-  hardware.graphics.enable32Bit = true;
 }


### PR DESCRIPTION
Eliza is the AmpareCore server.

Use the same configuration as jamie, except
`hardware.graphics.enable32Bit`, which is opiton for x86-64.

I also disabled `pcie_aspm` as a PCIe BUS error once happened, and several webpages mention that option might be related.

- quick test
```
nvidia-smi
docker run --rm -it --device=nvidia.com/gpu=all ubuntu:latest nvidia-smi
```

- cuda docker
```
docker pull nvidia/cuda:12.8.0-cudnn-devel-ubuntu24.04
docker run -it --name dev-cuda12.8 -v /scratch/$USER/work:/work -device=nvidia.com/gpu=all nvidia/cuda:12.8.0-cudnn-devel-ubuntu24.04
```

- test (in the container)
```
cd /work/
apt update
apt install git cmake
git clone https://github.com/NVIDIA/cuda-samples
cd cuda-samples
git checkout -b v12.8 tags/v12.8
mkdir build
cd build
cmake ..
make -j$(nproc)
./Samples/1_Utilities/deviceQuery/deviceQuery
```

- llama.cpp
```
git clone https://github.com/ggml-org/llama.cpp/
cd llama.cpp
apt install curl libcurl4-openssl-dev
cmake -B build -DGGML_CUDA=ON
cmake --build build --config Release -j $(nproc)
LLAMA_CACHE=/work/models ./build/bin/llama-cli -hf ggml-org/gemma-3-1b-it-GGUF --gpu-layers -1
```