### PR TITLE
Set file descriptor ulimit to 8196 on eliza

### DIFF
--- a/hosts/eliza.nix
+++ b/hosts/eliza.nix
@@ -8,9 +8,19 @@
 
   networking.hostName = "eliza";
 
-
   disko.rootDisk = "/dev/disk/by-id/nvme-SAMSUNG_MZQL23T8HCLS-00A07_S64HNN0XA20382";
 
   system.stateVersion = "24.11";
-}
 
+  security.pam.loginLimits = [
+    {
+      domain = "*";
+      type = "soft";
+      item = "nofile";
+      value = "8192";
+    }
+  ];
+  systemd.user.extraConfig = ''
+    DefaultLimitNOFILE=8192
+  '';
+}

--- a/hosts/eliza.nix
+++ b/hosts/eliza.nix
@@ -12,6 +12,8 @@
 
   system.stateVersion = "24.11";
 
+  simd.arch = "armv8.6-a";
+
   security.pam.loginLimits = [
     {
       domain = "*";


### PR DESCRIPTION
I keep running into "too many open files" while linking