### PR TITLE
Disable rpcbind service for NFSv4

### DIFF
--- a/modules/nfs/default.nix
+++ b/modules/nfs/default.nix
@@ -12,5 +12,6 @@
       2a09:80c0:102::f000:0 nfs
       2a09:80c0:102::f000:1 nfs-backup
     '';
+    services.rpcbind.enable = lib.mkForce false; # rpcbind is not needed for our NFSv4 but can be used for DDoS amplification
   };
 }


### PR DESCRIPTION
Disable rpcbind service as it's not needed for NFSv4. Needs testing. In particular i'm not sure about its applicability to servers.