### PR TITLE
snp without custom kernel

### DIFF
--- a/hosts/irene.nix
+++ b/hosts/irene.nix
@@ -7,6 +7,7 @@
     ../modules/vfio/iommu-amd.nix
     ../modules/dpdk.nix
     ../modules/elasticsearch.nix
+    ../modules/amd_sev_snp-vanilla.nix
   ];
 
   networking.hostName = "irene";
@@ -18,7 +19,6 @@
     "vm.overcommit_memory" = 1;
   };
   powerManagement.cpuFreqGovernor = "performance";
-  boot.kernelPackages = lib.mkForce pkgs.linuxPackages_6_12;
 
   system.stateVersion = "22.11";
   simd.arch = "znver4";

--- a/hosts/vislor.nix
+++ b/hosts/vislor.nix
@@ -3,7 +3,6 @@
     ../modules/hardware/poweredge7625.nix
     ../modules/nfs/client.nix
     ../modules/amd_sev_snp-vanilla.nix
-    ../modules/dpdk.nix
   ];
 
   disko.rootDisk = "/dev/disk/by-id/nvme-SAMSUNG_MZQL23T8HCLS-00A07_S64HNS0W800676";
@@ -19,5 +18,12 @@
   boot.kernelParams = [
     "nvme.poll_queues=4"
     "nvme_core.multipath=N"
+    "amd_iommu=on"
   ];
+
+  # Enable SR-IOV driver for Intel NIC
+  boot.kernelModules = [
+    "iavf"
+  ];
+
 }

--- a/hosts/vislor.nix
+++ b/hosts/vislor.nix
@@ -2,7 +2,7 @@
   imports = [
     ../modules/hardware/poweredge7625.nix
     ../modules/nfs/client.nix
-    ../modules/amd_sev_snp.nix
+    ../modules/amd_sev_snp-vanilla.nix
     ../modules/dpdk.nix
   ];
 
@@ -10,7 +10,7 @@
 
   networking.hostName = "vislor";
   # not in nixpkgs yet
-  # simd.arch = "zenver4";
+  simd.arch = "znver4";
 
   system.stateVersion = "23.05";
 

--- a/modules/amd_sev_snp-vanilla.nix
+++ b/modules/amd_sev_snp-vanilla.nix
@@ -1,0 +1,36 @@
+{ pkgs, lib, ... }:
+{
+  # Use 6.16 kernel for now
+  boot.kernelPackages = lib.mkForce pkgs.linuxPackages_6_16;
+  boot.zfs.package = pkgs.zfsUnstable; # needed for 6.9
+
+  boot.kernelPatches = [
+      {
+        name = "amd_sme-config";
+        patch = null;
+        extraConfig = ''
+          AMD_MEM_ENCRYPT y
+          CRYPTO_DEV_CCP y
+          CRYPTO_DEV_CCP_DD m
+          CRYPTO_DEV_SP_PSP y
+          KVM_AMD_SEV y
+          VFIO_DEVICE_CDEV y
+        '';
+      }
+  ]; 
+
+  boot.kernelParams = [
+    #"mem_encrypt=on"
+    "kvm_amd.sev=1"
+    "kvm_amd.sev_es=1"
+    "kvm_amd.sev_snp=1"
+    #"kvm.mmio_caching=on"
+    "sp5100_tco.blacklist=yes"
+
+    # this parameter exists on 6.9-
+    "kvm.gmem_2m_enabled=1"
+  ];
+
+  # enable libvirtd service
+  virtualisation.libvirtd.enable = true;
+}


### PR DESCRIPTION
- **modules: add module 6.16 kernel from Nix with SEV-SNP support**
- **vislor: switch to vanilla snp kernel**
- **vislor: remove dpdk, enable iavf module, explicitly enable iommu**
- **irene: enable SEV-SNP kernel**
