### PR TITLE
enable nfs v3 and v4

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -128,6 +128,8 @@ Astrid also hosts the buildbot master server with Graham as the buildbot worker.
 
 ## Morello (ARM64)
 
+Ace is currently running Debian. To add users, see [these instructions](./morello.md).
+
 - [ace](./hosts/ace.md) (Morello)
   - For debugging, see [these instructions](./morello.md)
  

--- a/docs/morello.md
+++ b/docs/morello.md
@@ -1,3 +1,12 @@
+# Adding New Users
+
+When running Morello Debian, adding new users must be done manually.
+1. Create the user with the same uid as specified in `modules/users/*.nix`.
+2. Put the ssh keys into `/etc/ssh/authorized_keys.d/$USER`
+3. `chown $USER:users /etc/ssh/authorized_keys.d/$USER`
+4. `chmod 600 /etc/ssh/authorized_keys/$USER`
+
+
 # Debugging
 
 Connect your machine to the board using debug USB cable.

--- a/modules/nfs/server.nix
+++ b/modules/nfs/server.nix
@@ -84,6 +84,11 @@
         /export/share 2a09:80c0:102::/64(async,rw,nohide,insecure,no_subtree_check,no_root_squash,fsid=26) ${lib.concatStringsSep " " exportShare}
       '';
 
+    services.nfs.server.extraNfsdConfig = ''
+      vers3 = y
+      vers4 = y
+    '';
+
     systemd.tmpfiles.rules =
       let
         loginUsers = lib.filterAttrs (_n: v: v.isNormalUser) config.users.users;


### PR DESCRIPTION
We need both versions to be able to mount them from the prebuilt Morello Debian image.