### PR TITLE
install-iso: use nixos.release instead of nixos.version for system.stateVersion

### DIFF
--- a/pkgs/install-iso/base-config.nix
+++ b/pkgs/install-iso/base-config.nix
@@ -3,7 +3,7 @@
 , config
 , ...
 }: {
-  system.stateVersion = config.system.nixos.version;
+  system.stateVersion = config.system.nixos.release;
 
   networking.firewall.enable = false;
 


### PR DESCRIPTION
Otherwise we run into errors like:
```
       - 25.05.20251202.cdff0c1 is an invalid value for 'system.stateVersion'; it must be in the format "YY.MM",
       which corresponds to a prior release of NixOS.
```