### PR TITLE
flake: build eliza under aarch64-linux checks

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -468,11 +468,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776912132,
-        "narHash": "sha256-UDR6PtHacMhAQJ8SPNbPROaxbtl2Pgjww0TzipTsTZE=",
+        "lastModified": 1776989454,
+        "narHash": "sha256-eblB9KOUwNtcyf/9r7dQrtvpdPGcAzNgqOm0j7MsFHQ=",
         "owner": "numtide",
         "repo": "srvos",
-        "rev": "e9ff039a72ff2c06271d5002eb431c443abf69fa",
+        "rev": "4258a8ef8ef7442ed9c7d4833cd5614cd1fed4ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION

eliza is an aarch64 host (supermicro ARS-211M-NR) but was missing from
the explicit aarch64-linux list, so the x86_64-linux fallback picked it
up and buildbot published its closure as x86_64-linux.nixos-eliza. The
on-host auto-upgrade service derives the URL from `uname -m` and has
therefore been 404ing for months, leaving the machine on a January
generation with a nix-daemon that crashes on recursive-nix builds.
