### PR TITLE
blacklist nouveau driver globally

### DIFF
--- a/configurations.nix
+++ b/configurations.nix
@@ -76,6 +76,7 @@ let
       ./modules/doctor-VMs.nix
       ./modules/lawful-access
       ./modules/nix-index.nix
+      ./modules/no-nouveau.nix
     ];
 
   pkgsForSystem = system: import nixpkgs {

--- a/modules/no-nouveau.nix
+++ b/modules/no-nouveau.nix
@@ -1,0 +1,4 @@
+{ lib, pkgs, ... }:
+{
+  boot.blacklistedKernelModules = [ "nouveau" ];
+}


### PR DESCRIPTION
Causes various unexpected issues on servers with NVIDIA hardware. We do not have any hardware well supported by that driver.
