### PR TITLE
Drop stale flake-parts override for buildbot-nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,6 @@
 
     buildbot-nix.url = "github:nix-community/buildbot-nix";
     buildbot-nix.inputs.nixpkgs.follows = "nixpkgs";
-    buildbot-nix.inputs.flake-parts.follows = "flake-parts";
     buildbot-nix.inputs.treefmt-nix.follows = "treefmt-nix";
 
     niks3.url = "github:Mic92/niks3";


### PR DESCRIPTION
buildbot-nix removed its flake-parts input, so the follows override now
triggers a warning about overriding a non-existent input on every
evaluation.
