### PR TITLE
niks3: bump to be78b25 and allow Mic92/niks3-action via OIDC

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -252,11 +252,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776983317,
-        "narHash": "sha256-qwBU/6g7mT0zAMwFqSZlC4JTJbG+n3y9wUGBBF6opD8=",
+        "lastModified": 1778422863,
+        "narHash": "sha256-REDH5/tk0lbufKsFeT2oR3Mc2tGmNH7VZkE2Qnmj2oM=",
         "owner": "Mic92",
         "repo": "niks3",
-        "rev": "8d90f2b739a6b69570b75d017a94e3d14561d2a8",
+        "rev": "be78b25ef529d58b7bf44152c4d5da17aab4a9b7",
         "type": "github"
       },
       "original": {

--- a/modules/niks3/default.nix
+++ b/modules/niks3/default.nix
@@ -38,7 +38,11 @@
       issuer = "https://token.actions.githubusercontent.com";
       audience = "https://niks3.dos.cit.tum.de";
       boundClaims = {
-        repository_owner = [ "TUM-DSE" ];
+        repository = [
+          "TUM-DSE/*"
+          # Dogfooding the GitHub Action's own CI.
+          "Mic92/niks3-action"
+        ];
       };
     };
 


### PR DESCRIPTION
Pulls in the /api/cache-config endpoint needed by the GitHub Action (Mic92/niks3#375).

Switches boundClaims from `repository_owner` to a `repository` allowlist so we can dogfood the action from its own CI without opening uploads to all of `Mic92/*`.

Already deployed to astrid.