### PR TITLE
nix-daemon: replace nix.gc/optimise with fast-nix-gc

### DIFF
--- a/configurations.nix
+++ b/configurations.nix
@@ -39,6 +39,8 @@ let
     srvos.nixosModules.mixins-terminfo
     srvos.nixosModules.mixins-nix-experimental
 
+    inputs.fast-nix-gc.nixosModules.default
+
     sops-nix.nixosModules.sops
     ({ pkgs
      , config

--- a/flake.lock
+++ b/flake.lock
@@ -69,6 +69,29 @@
         "type": "github"
       }
     },
+    "fast-nix-gc": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778829034,
+        "narHash": "sha256-rezIgc+Dye1hBFBOW+yGXhNhoj/FpQQO+guZu904TVg=",
+        "owner": "Mic92",
+        "repo": "fast-nix-gc",
+        "rev": "6c6c4e7edaf7e58c4d549d3cda3b74ebddb240b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "fast-nix-gc",
+        "type": "github"
+      }
+    },
     "fenix": {
       "inputs": {
         "nixpkgs": [
@@ -422,6 +445,7 @@
       "inputs": {
         "buildbot-nix": "buildbot-nix",
         "disko": "disko",
+        "fast-nix-gc": "fast-nix-gc",
         "flake-parts": "flake-parts_2",
         "flake-registry": "flake-registry",
         "home-manager": "home-manager",

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,10 @@
     hosthog.inputs.nixpkgs.follows = "nixpkgs";
     hosthog.inputs.flake-parts.follows = "flake-parts";
 
+    fast-nix-gc.url = "github:Mic92/fast-nix-gc";
+    fast-nix-gc.inputs.nixpkgs.follows = "nixpkgs";
+    fast-nix-gc.inputs.treefmt-nix.follows = "treefmt-nix";
+
     flake-registry.url = "github:NixOS/flake-registry";
     flake-registry.flake = false;
   };

--- a/modules/nix-daemon.nix
+++ b/modules/nix-daemon.nix
@@ -22,10 +22,22 @@ in
   imports = [ ./builder.nix ];
 
   config = {
+    services.fast-nix-gc = {
+      enable = true;
+      automatic = true;
+      dates = "03:15";
+      deleteOlderThan = "14d";
+    };
+
+    services.fast-nix-optimise = {
+      enable = true;
+      automatic = true;
+      dates = "04:15";
+    };
+
     nix = {
-      gc.automatic = true;
-      gc.dates = "03:15";
-      gc.options = "--delete-older-than 14d";
+      # Replaced by services.fast-nix-optimise; srvos enables this by default.
+      optimise.automatic = lib.mkForce false;
 
       # https://github.com/NixOS/nix/issues/719
 


### PR DESCRIPTION
Stock nix-collect-garbage issues one SQLite query per store path and
takes 20-30 minutes on our build servers with large stores. fast-nix-gc
loads the reference graph into memory once and runs the liveness BFS
over integer node ids, bringing GC down to seconds. fast-nix-optimise
replaces nix-store --optimise with the same on-disk .links layout but
parallel hashing/linking and a fast path that skips already-deduped
files via readdir d_ino.

Schedules unchanged: GC daily at 03:15 deleting generations older than
14d, optimise daily at 04:15. nix.optimise.automatic from srvos is
forced off to avoid running both.
