### PR TITLE
Switch tinc to tincr (Rust rewrite)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,6 +27,21 @@
         "type": "github"
       }
     },
+    "crane": {
+      "locked": {
+        "lastModified": 1776479158,
+        "narHash": "sha256-P7TLDtRgAxmo0Bdw8fkJrrBpX/8/WhO6Bm/uCfl6jXY=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "3fbd73bdd9eb572209fdf094abad19d9b6d147b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "cuda-legacy": {
       "inputs": {
         "flake-parts": [
@@ -421,6 +436,7 @@
         "retiolum": "retiolum",
         "sops-nix": "sops-nix",
         "srvos": "srvos",
+        "tincr": "tincr",
         "treefmt-nix": "treefmt-nix"
       }
     },
@@ -478,6 +494,30 @@
       "original": {
         "owner": "numtide",
         "repo": "srvos",
+        "type": "github"
+      }
+    },
+    "tincr": {
+      "inputs": {
+        "crane": "crane",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778860169,
+        "narHash": "sha256-Rjs4MXVEtER1C5XLARnnsdhSNcRawGuLDnMPBqz70Ls=",
+        "owner": "Mic92",
+        "repo": "tincr",
+        "rev": "e30e116a0307f91d0bec161515aa6efacd5b7bc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "tincr",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,10 @@
     retiolum.url = "github:Mic92/retiolum";
     retiolum.inputs.nixpkgs.follows = "nixpkgs";
 
+    tincr.url = "github:Mic92/tincr";
+    tincr.inputs.nixpkgs.follows = "nixpkgs";
+    tincr.inputs.treefmt-nix.follows = "treefmt-nix";
+
     srvos.url = "github:numtide/srvos";
     # actually not used when using the modules but than nothing ever will try to fetch this nixpkgs variant
     srvos.inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/tinc.nix
+++ b/modules/tinc.nix
@@ -1,12 +1,13 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, inputs, ... }:
 {
   sops.secrets = lib.mkIf config.users.withSops {
     tinc-key = { };
     tinc-legacy-key = { };
   };
 
-  # only allow connections from hosts specified in our retiolum hosts.
   services.tinc.networks.retiolum = {
+    # Rust rewrite, drop-in for tinc_pre on the NixOS module's argv.
+    package = inputs.tincr.packages.${pkgs.stdenv.hostPlatform.system}.tincd;
     extraConfig = "StrictSubnets yes";
     ed25519PrivateKeyFile = lib.mkIf (
       config.sops.secrets ? "tinc-key"
@@ -15,5 +16,15 @@
     rsaPrivateKeyFile = lib.mkIf (
       config.sops.secrets ? "tinc-legacy-key"
     ) config.sops.secrets."tinc-legacy-key".path;
+  };
+
+  # /etc/tinc/retiolum is read-only on NixOS (built from the store);
+  # the Rust tincd's address cache falls back to $STATE_DIRECTORY/cache
+  # when confbase isn't writable.
+  systemd.services."tinc.retiolum" = {
+    serviceConfig.StateDirectory = "tinc/retiolum";
+    preStart = lib.mkAfter ''
+      install -d -m 0750 -o tinc-retiolum -g tinc-retiolum /var/lib/tinc/retiolum/cache
+    '';
   };
 }


### PR DESCRIPTION
Switch from unmaintained C tinc to the tincr Rust drop-in replacement, matching what's already running in the dotfiles repo. Includes the StateDirectory/cache workaround for NixOS read-only confbase.