### PR TITLE
modules: replace deprecated pkgs.system with pkgs.stdenv.hostPlatform.system

### DIFF
--- a/modules/buildbot/master.nix
+++ b/modules/buildbot/master.nix
@@ -40,7 +40,7 @@
       enable = true;
       serverUrl = "https://niks3.dos.cit.tum.de";
       authTokenFile = config.sops.secrets.niks3-api-token.path;
-      package = inputs.niks3.packages.${pkgs.system}.default;
+      package = inputs.niks3.packages.${pkgs.stdenv.hostPlatform.system}.default;
     };
   };
 

--- a/modules/buildbot/worker.nix
+++ b/modules/buildbot/worker.nix
@@ -35,6 +35,6 @@
 
   # niks3 for uploading build results to cache
   systemd.services.buildbot-worker.path = [
-    inputs.niks3.packages.${pkgs.system}.default
+    inputs.niks3.packages.${pkgs.stdenv.hostPlatform.system}.default
   ];
 }

--- a/modules/lrz-gitlab-classroom/frontend.nix
+++ b/modules/lrz-gitlab-classroom/frontend.nix
@@ -1,6 +1,6 @@
 { pkgs, config, ... }: let
   lrz-gitlab-classroom = builtins.getFlake "github:pogobanane/lrz-gitlab-classroom/e8b5806b3784da7cb249539871a8f7d9be6d3a1a";
-  frontend = lrz-gitlab-classroom.packages.${pkgs.system}.frontend;
+  frontend = lrz-gitlab-classroom.packages.${pkgs.stdenv.hostPlatform.system}.frontend;
   user = "lrz-gitlab-teacher";
 in {
   services.nginx.virtualHosts."assignments.dos.cit.tum.de" = {

--- a/modules/netboot/netboot.nix
+++ b/modules/netboot/netboot.nix
@@ -5,7 +5,7 @@
 }:
 let
   bootSystem = nixosSystem {
-    system = pkgs.system;
+    system = pkgs.stdenv.hostPlatform.system;
     modules = [
       ./base-config.nix
       ./zfs.nix

--- a/modules/nix-index.nix
+++ b/modules/nix-index.nix
@@ -3,6 +3,6 @@
 
   imports = [ inputs.nix-index-database.nixosModules.nix-index ];
   # we don't have a pre-built database for this platform
-  programs.nix-index.enable = pkgs.stdenv.system != "riscv64-linux";
-  programs.nix-index-database.comma.enable = pkgs.stdenv.system != "riscv64-linux";
+  programs.nix-index.enable = pkgs.stdenv.hostPlatform.system != "riscv64-linux";
+  programs.nix-index-database.comma.enable = pkgs.stdenv.hostPlatform.system != "riscv64-linux";
 }


### PR DESCRIPTION

nixpkgs deprecated the top-level 'system' alias in favor of
stdenv.hostPlatform.system, which is unambiguous about which platform
is meant in cross-compilation scenarios. Switch to silence the
deprecation warning.
