### PR TITLE
home-manager: pin to pre-modular-services rev

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -171,17 +171,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1779726825,
-        "narHash": "sha256-RUkMrREjKDQrA+dA9+xZviGAxM5W1aVdyOr/bSYpHrE=",
+        "lastModified": 1777894865,
+        "narHash": "sha256-agINDb/tr4v2uaVmgE/i0dY1M2JJdzUI/Caup/MWEGU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b179bde238977f7d4454fc770b1a727eaf55111c",
+        "rev": "9c6f1307e1d76a2285d8001e1b8bc281bfe15dac",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-26.05",
         "repo": "home-manager",
+        "rev": "9c6f1307e1d76a2285d8001e1b8bc281bfe15dac",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     nix-index-database.url = "github:Mic92/nix-index-database";
     nix-index-database.inputs.nixpkgs.follows = "nixpkgs";
 
-    home-manager.url = "github:nix-community/home-manager/release-26.05";
+    home-manager.url = "github:nix-community/home-manager/9c6f1307e1d76a2285d8001e1b8bc281bfe15dac";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
     treefmt-nix.url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
home-manager master requires nixpkgs `lib/services` since May 4, but our nixpkgs pin (ce56a0c, May 16) predates its addition to nixpkgs (May 19). Every `home-manager switch` on the cluster currently fails with:

```
error: path '/nix/store/z5sm67a...-source/lib/services/lib.nix' does not exist
```

Temporary unblock: pin home-manager to `9c6f130` (last rev before the modular-services requirement). Will be reverted by the nixpkgs 26.05 bump (branch `nixpkgs-26.05`, PR follows).

Verified: `homeManagerConfiguration` evals, eliza toplevel evals.