### PR TITLE
flake: add home-manager eval check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -98,7 +98,7 @@
           ./templates
         ];
         perSystem =
-          { self', system, ... }:
+          { self', system, pkgs, ... }:
           {
             _module.args.pkgs = import inputs.nixpkgs {
               inherit system;
@@ -141,8 +141,24 @@
                   )
                 );
                 devShells = lib.mapAttrs' (n: lib.nameValuePair "devShell-${n}") self'.devShells;
+                # Users run home-manager standalone against the system
+                # registry pins, so home-manager/nixpkgs skew breaks
+                # `home-manager switch` without failing any host build.
+                homeManager = {
+                  home-manager-eval =
+                    (inputs.home-manager.lib.homeManagerConfiguration {
+                      inherit pkgs;
+                      modules = [
+                        {
+                          home.username = "ci";
+                          home.homeDirectory = "/home/ci";
+                          home.stateVersion = "26.05";
+                        }
+                      ];
+                    }).activationPackage;
+                };
               in
-              nixosMachines // devShells;
+              nixosMachines // devShells // homeManager;
           };
       }
     )).config.flake;


### PR DESCRIPTION
Follow-up to #1605. Users run home-manager standalone against the system registry pins, so home-manager/nixpkgs skew breaks `home-manager switch` while every host build stays green. Evaluate a minimal home-manager configuration in `checks` so buildbot catches it.