### PR TITLE
fluent-bit: fix wasm filter OOM panics

### DIFF
--- a/modules/fluent-bit-filter-go/filter.go
+++ b/modules/fluent-bit-filter-go/filter.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"runtime"
 	"strings"
 	"unsafe"
 )
@@ -47,6 +48,12 @@ type outputRecord struct {
 //export go_filter
 func go_filter(tag *uint8, tag_len uint, time_sec uint, time_nsec uint, record *uint8, record_len uint) *uint8 {
 	brecord := unsafe.Slice(record, record_len)
+
+	// The wasm instance is persistent for the lifetime of fluent-bit and
+	// wasm linear memory never shrinks. Without an explicit collection per
+	// call, TinyGo's heap slowly grows until it hits the 4GB wasm32 limit
+	// and panics with "runtime error: out of memory", dropping records.
+	defer runtime.GC()
 
 	result := processRecord(string(brecord))
 	if result == "" {

--- a/modules/fluent-bit.nix
+++ b/modules/fluent-bit.nix
@@ -102,6 +102,9 @@ in
 
   systemd.services.fluent-bit = lib.mkIf (config.users.withSops) {
     serviceConfig = {
+      # Safety net: the wasm filter instance is persistent and wasm linear
+      # memory never shrinks, so restart daily to bound memory growth.
+      RuntimeMaxSec = "1d";
       StateDirectory = "fluent-bit";
       RuntimeDirectory = "fluent-bit";
       LoadCredential = "loki-password:${passwordFile}";


### PR DESCRIPTION
The wasm filter instance is persistent for the lifetime of fluent-bit
and wasm32 linear memory never shrinks. TinyGo's conservative GC let
the heap grow until it hit the 4GB wasm32 limit, after which go_filter
panicked with "runtime error: out of memory" every ~15 minutes
(observed on graham, fluent-bit RSS at 4.3GB), silently dropping log
records on each panic.

Force a garbage collection after every invocation to keep the heap
small, and restart fluent-bit daily via RuntimeMaxSec as a safety net
against any remaining slow growth. The upstream module sets
Restart=always, so the periodic stop results in a clean restart.
