### PR TITLE
niks3 cache: disable nginx proxy buffering for S3 passthrough

### DIFF
--- a/modules/niks3/reverse-proxy.nix
+++ b/modules/niks3/reverse-proxy.nix
@@ -53,6 +53,11 @@
         limit_except GET {
           deny all;
         }
+        # Stream NARs straight from S3. Buffering would spool large objects
+        # into nginx's proxy_temp dir, which on doctor lives on a tiny tmpfs
+        # /tmp (PrivateTmp) and fills up under concurrent fetches.
+        proxy_buffering off;
+        proxy_request_buffering off;
         proxy_ssl_server_name on;
         proxy_set_header Host dos-s3-1.s3.ito.cit.tum.de;
         proxy_set_header Authorization $s3v4_authorization;


### PR DESCRIPTION

nginx on doctor runs with PrivateTmp=yes and its /tmp is backed by a
192MB tmpfs. With proxy buffering enabled, large NAR objects streamed
from S3 get spooled into the proxy_temp dir under /tmp, which fills up
under concurrent fetches and yields 'No space left on device' crit
errors and broken downloads. Stream directly from S3 instead.


