### PR TITLE
auto-upgrade: restore nix-outputs endpoint after nixbot migration

### DIFF
--- a/modules/auto-upgrade.nix
+++ b/modules/auto-upgrade.nix
@@ -30,7 +30,7 @@
       set -euo pipefail
 
       hostname=$(uname -n)
-      p=$(curl -fsSL "https://buildbot.dse.in.tum.de/nix-outputs/TUM-DSE/doctor-cluster-config/master/${pkgs.stdenv.buildPlatform.system}.nixos-$hostname")
+      p=$(curl -fsSL "https://buildbot.dse.in.tum.de/nix-outputs/github/TUM-DSE/doctor-cluster-config/master/${pkgs.stdenv.buildPlatform.system}.nixos-$hostname")
 
       if [[ "$(readlink /run/current-system)" == "$p" ]]; then
         echo "Already at $p, nothing to do"

--- a/modules/buildbot/nixbot.nix
+++ b/modules/buildbot/nixbot.nix
@@ -16,8 +16,13 @@
     domain = "buildbot.dse.in.tum.de";
     # Behind doctor's TLS reverse proxy; generate https:// URLs.
     useHTTPS = true;
-    # External reverse proxy handles TLS, so do not manage nginx here.
-    nginx.enable = false;
+    # Manage the local nginx vhost so it serves /nix-outputs/ (consumed by
+    # auto-upgrade) alongside the proxied UI. doctor terminates TLS, so no
+    # ACME/forceSSL here; this vhost stays plain http on port 80.
+    nginx = {
+      enable = true;
+      enableACME = false;
+    };
 
     buildSystems = [
       "i686-linux"
@@ -85,8 +90,7 @@
     niks3-api-token.sopsFile = ../niks3/secrets.yml;
   };
 
-  # nixbot listens on its TCP port; doctor's reverse proxy connects to it.
-  networking.firewall.allowedTCPPorts = [
-    config.services.nixbot.port
-  ];
+  # nixbot's managed nginx vhost listens on port 80; doctor's reverse proxy
+  # connects to it (and through it to /nix-outputs/).
+  networking.firewall.allowedTCPPorts = [ 80 ];
 }

--- a/modules/buildbot/reverse-proxy.nix
+++ b/modules/buildbot/reverse-proxy.nix
@@ -4,8 +4,10 @@
     forceSSL = true;
     enableACME = true;
 
+    # Proxy to graham's nginx (port 80), which serves the nixbot UI plus the
+    # /nix-outputs/ tree consumed by auto-upgrade.
     locations."/" = {
-      proxyPass = "http://buildbot-master:8010";
+      proxyPass = "http://buildbot-master";
       proxyWebsockets = true;
       extraConfig = ''
         # Webhook deliveries can exceed nginx's 1m default


### PR DESCRIPTION

The buildbot->nixbot migration broke the HTTP endpoint that auto-upgrade
polls for the latest per-host system closure.

nixbot changed the outputs URL layout to be forge-scoped
(/nix-outputs/<forge>/<owner>/<repo>/<branch>/<attr>), so the old
github-less URL 404s. Insert the github forge segment.

nixbot also only serves /nix-outputs/ from its own managed nginx vhost
(via alias); the python app does not. The migration had disabled that
vhost and pointed doctor`s reverse proxy directly at the app port, so
the endpoint vanished entirely. Re-enable the managed nginx on graham
(plain http on port 80, since doctor terminates TLS) and proxy doctor to
graham:80, mirroring the previous buildbot-nix architecture.
