### PR TITLE
jamie: disable nvidia-container-toolkit

### DIFF
--- a/hosts/jamie.nix
+++ b/hosts/jamie.nix
@@ -14,6 +14,10 @@
     ../modules/tribuchet
   ];
 
+  # H100 runs in Confidential Compute mode for SEV-SNP passthrough; the host
+  # driver cannot initialize it, so CDI generation fails and breaks activation.
+  hardware.nvidia-container-toolkit.enable = false;
+
   simd.arch = "znver4";
 
   disko.rootDisk = "/dev/disk/by-id/nvme-SAMSUNG_MZQL23T8HCLS-00A07_S64HNJ0X815786";

--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -20,5 +20,5 @@
   services.xserver.videoDrivers = [ "nvidia" ];
 
   virtualisation.docker.enable = true;
-  hardware.nvidia-container-toolkit.enable = true;
+  hardware.nvidia-container-toolkit.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
The H100 in jamie is switched into Confidential Compute mode for SEV-SNP
GPU passthrough, so the host driver cannot initialize it (nvidia-smi sees
no devices). The CDI generator then produces an empty spec and fails,
which makes every switch-to-configuration exit with status 4 and leaves
auto-upgrade runs half-applied.

Make the toolkit default overridable via mkDefault in the nvidia profile
and turn it off on jamie.
