### PR TITLE
Add Coyote kernel driver to Nix configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "coyote": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783057848,
+        "narHash": "sha256-+TTF9jS+g0fuXTxfDmhrTvOowuxRtm/dae/PfjfQBBk=",
+        "owner": "fpgasystems",
+        "repo": "Coyote",
+        "rev": "9c00353a474ad78ddafae7506c2d08461f6b6d1a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fpgasystems",
+        "repo": "Coyote",
+        "rev": "9c00353a474ad78ddafae7506c2d08461f6b6d1a",
+        "type": "github"
+      }
+    },
     "crane": {
       "locked": {
         "lastModified": 1781825982,
@@ -444,6 +461,7 @@
     },
     "root": {
       "inputs": {
+        "coyote": "coyote",
         "crane": "crane",
         "disko": "disko",
         "fast-nix-gc": "fast-nix-gc",

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,12 @@
 
     flake-registry.url = "github:NixOS/flake-registry";
     flake-registry.flake = false;
+
+    # Coyote source pinned to the required commit.
+    coyote = {
+      url = "github:fpgasystems/Coyote/9c00353a474ad78ddafae7506c2d08461f6b6d1a";
+      flake = false;
+    };
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -83,11 +83,8 @@
     flake-registry.url = "github:NixOS/flake-registry";
     flake-registry.flake = false;
 
-    # Coyote source pinned to the required commit.
-    coyote = {
-      url = "github:fpgasystems/Coyote/9c00353a474ad78ddafae7506c2d08461f6b6d1a";
-      flake = false;
-    };
+    coyote.url = "github:fpgasystems/Coyote/9c00353a474ad78ddafae7506c2d08461f6b6d1a";
+    coyote.flake = false;
   };
 
   outputs =

--- a/hosts/clara.nix
+++ b/hosts/clara.nix
@@ -22,6 +22,8 @@
 
   boot.hugepages1GB.number = 8;
 
+  hardware.xilinx.coyote-driver.enable = true;
+
   simd.arch = "znver3";
   system.stateVersion = "22.11";
 

--- a/modules/xilinx.nix
+++ b/modules/xilinx.nix
@@ -9,6 +9,34 @@ let
   packages = self.packages.${pkgs.stdenv.hostPlatform.system};
   xrt-drivers = packages.xrt-drivers.override { inherit (config.boot.kernelPackages) kernel; };
   coyote-driver = packages.coyote-driver.override { inherit (config.boot.kernelPackages) kernel; };
+
+  # Usage: coyote-load [<module params>...]
+  #   e.g. coyote-load ip_addr=10.0.0.1 mac_addr=00:0a:35:...
+  # Loads a coyote_driver.ko that matches the *running* kernel.
+  # NixOS kmod already searches /run/booted-system and /run/current-system,
+  # so plain modprobe works whenever either generation was built with the
+  # option enabled. The nix-build fallback covers the case where the
+  # config's kernel has moved on but the machine has not rebooted yet.
+  coyote-load = pkgs.writeShellApplication {
+    name = "coyote-load";
+    runtimeInputs = [ pkgs.kmod ];
+    text = ''
+      if sudo modprobe coyote_driver "$@"; then
+        exit 0
+      fi
+      echo "coyote-load: modprobe failed, rebuilding against booted kernel via /run/booted-system/flake" >&2
+      flake=$(realpath /run/booted-system/flake)
+      host=$(cat /proc/sys/kernel/hostname)
+      out=$(nix build --no-link --print-out-paths --impure --expr "
+        let
+          booted = (builtins.getFlake \"path:$flake\").nixosConfigurations.\"$host\".config;
+          current = builtins.getFlake \"path:${self}\";
+        in current.packages.${pkgs.stdenv.hostPlatform.system}.coyote-driver.override {
+          inherit (booted.boot.kernelPackages) kernel;
+        }")
+      exec sudo insmod "$out/lib/modules/$(uname -r)/extra/coyote_driver.ko" "$@"
+    '';
+  };
 in
 {
   options = {
@@ -35,21 +63,16 @@ in
         vivadoVersion = "2025.1";
       })
       packages.xntools-core
-    ];
+    ] ++ lib.optional config.hardware.xilinx.coyote-driver.enable coyote-load;
 
     services.udev.packages = [ packages.xilinx-cable-drivers ];
 
     # 6.0+ kernel
     boot.extraModulePackages =
-      lib.optional
-        config.hardware.xilinx.xrt-drivers.enable
-        xrt-drivers
-      ++ lib.optional
-        config.hardware.xilinx.coyote-driver.enable
-        coyote-driver;
-
-    # The Coyote module is deliberately not added to boot.kernelModules.
-    # It will be loaded manually after programming the FPGA.
+      lib.optional config.hardware.xilinx.xrt-drivers.enable xrt-drivers
+      ++ lib.optional config.hardware.xilinx.coyote-driver.enable coyote-driver;
+    # coyote_driver is loaded manually (via `coyote-load`) after programming the FPGA,
+    # so no boot.kernelModules entry.
 
     # hardware.graphics.extraPackages = [ packages.xrt ];
   };

--- a/modules/xilinx.nix
+++ b/modules/xilinx.nix
@@ -8,10 +8,12 @@
 let
   packages = self.packages.${pkgs.stdenv.hostPlatform.system};
   xrt-drivers = packages.xrt-drivers.override { inherit (config.boot.kernelPackages) kernel; };
+  coyote-driver = packages.coyote-driver.override { inherit (config.boot.kernelPackages) kernel; };
 in
 {
   options = {
     hardware.xilinx.xrt-drivers.enable = lib.mkEnableOption "Propritary kernel drivers for flashing firmware";
+    hardware.xilinx.coyote-driver.enable = lib.mkEnableOption "Coyote FPGA kernel driver";
   };
 
   config = {
@@ -38,7 +40,16 @@ in
     services.udev.packages = [ packages.xilinx-cable-drivers ];
 
     # 6.0+ kernel
-    boot.extraModulePackages = lib.optional (config.hardware.xilinx.xrt-drivers.enable) xrt-drivers;
+    boot.extraModulePackages =
+      lib.optional
+        config.hardware.xilinx.xrt-drivers.enable
+        xrt-drivers
+      ++ lib.optional
+        config.hardware.xilinx.coyote-driver.enable
+        coyote-driver;
+
+    # The Coyote module is deliberately not added to boot.kernelModules.
+    # It will be loaded manually after programming the FPGA.
 
     # hardware.graphics.extraPackages = [ packages.xrt ];
   };

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -15,6 +15,12 @@
         inherit (self.packages.x86_64-linux) xrt;
         inherit (pkgs.linuxPackages_6_8) kernel;
       };
+
+      coyote-driver = pkgs.callPackage ./xilinx/coyote-driver.nix {
+        src = inputs.coyote;
+        inherit (pkgs.linuxPackages_6_8) kernel;
+      };
+
       xntools-core = pkgs.callPackage ./xilinx/xntools-core.nix { };
 
       firmware-sn1000 = pkgs.callPackage ./xilinx/firmware-sn1000.nix { };

--- a/pkgs/flake-module.nix
+++ b/pkgs/flake-module.nix
@@ -15,12 +15,10 @@
         inherit (self.packages.x86_64-linux) xrt;
         inherit (pkgs.linuxPackages_6_8) kernel;
       };
-
       coyote-driver = pkgs.callPackage ./xilinx/coyote-driver.nix {
         src = inputs.coyote;
         inherit (pkgs.linuxPackages_6_8) kernel;
       };
-
       xntools-core = pkgs.callPackage ./xilinx/xntools-core.nix { };
 
       firmware-sn1000 = pkgs.callPackage ./xilinx/firmware-sn1000.nix { };

--- a/pkgs/xilinx/coyote-driver.nix
+++ b/pkgs/xilinx/coyote-driver.nix
@@ -6,13 +6,6 @@
   coyotePlatform ? "ultrascale_plus",
 }:
 
-assert lib.assertMsg
-  (builtins.elem coyotePlatform [
-    "ultrascale_plus"
-    "versal"
-  ])
-  "coyote-driver: coyotePlatform must be either 'ultrascale_plus' or 'versal'";
-
 let
   kernelDir = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
 in
@@ -20,50 +13,33 @@ stdenv.mkDerivation {
   pname = "coyote-driver";
   version = "0-unstable-${src.shortRev or "dirty"}-${kernel.version}";
 
-  # `src` is supplied by the pinned, non-flake Coyote input declared in
-  # the repository's root flake.nix. Only the driver subtree is copied into
-  # the writable build directory.
   inherit src;
   dontUnpack = true;
 
-  # Provides the compiler and other tools needed to build an out-of-tree
-  # module against the selected NixOS kernel.
   nativeBuildInputs = kernel.moduleBuildDependencies;
-
-  # Kernel modules must not be built with the normal userspace PIE/PIC
-  # hardening flags.
   hardeningDisable = [ "pic" ];
-
   enableParallelBuilding = true;
 
   buildPhase = ''
     runHook preBuild
-
     cp -r ${src}/driver ./driver
     chmod -R u+w ./driver
-
-    pushd ./driver
-    make \
-      -j"$NIX_BUILD_CORES" \
+    cd ./driver
+    make -j"$NIX_BUILD_CORES" \
       KERNELDIR="${kernelDir}" \
       TARGET_PLATFORM="${coyotePlatform}"
-    popd
-
+    cd ..
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
-
     install -Dm444 driver/build/coyote_driver.ko \
       "$out/lib/modules/${kernel.modDirVersion}/extra/coyote_driver.ko"
-
     runHook postInstall
   '';
 
-  passthru = {
-    inherit src coyotePlatform kernel;
-  };
+  passthru = { inherit coyotePlatform kernel; };
 
   meta = {
     description = "Coyote FPGA Linux kernel driver";

--- a/pkgs/xilinx/coyote-driver.nix
+++ b/pkgs/xilinx/coyote-driver.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  kernel,
+  src,
+  coyotePlatform ? "ultrascale_plus",
+}:
+
+assert lib.assertMsg
+  (builtins.elem coyotePlatform [
+    "ultrascale_plus"
+    "versal"
+  ])
+  "coyote-driver: coyotePlatform must be either 'ultrascale_plus' or 'versal'";
+
+let
+  kernelDir = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+in
+stdenv.mkDerivation {
+  pname = "coyote-driver";
+  version = "0-unstable-${src.shortRev or "dirty"}-${kernel.version}";
+
+  # `src` is supplied by the pinned, non-flake Coyote input declared in
+  # the repository's root flake.nix. Only the driver subtree is copied into
+  # the writable build directory.
+  inherit src;
+  dontUnpack = true;
+
+  # Provides the compiler and other tools needed to build an out-of-tree
+  # module against the selected NixOS kernel.
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  # Kernel modules must not be built with the normal userspace PIE/PIC
+  # hardening flags.
+  hardeningDisable = [ "pic" ];
+
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    cp -r ${src}/driver ./driver
+    chmod -R u+w ./driver
+
+    pushd ./driver
+    make \
+      -j"$NIX_BUILD_CORES" \
+      KERNELDIR="${kernelDir}" \
+      TARGET_PLATFORM="${coyotePlatform}"
+    popd
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 driver/build/coyote_driver.ko \
+      "$out/lib/modules/${kernel.modDirVersion}/extra/coyote_driver.ko"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit src coyotePlatform kernel;
+  };
+
+  meta = {
+    description = "Coyote FPGA Linux kernel driver";
+    homepage = "https://github.com/fpgasystems/Coyote";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
The current Coyote driver has a problem loading into the kernel `Unknown symbol devmap_managed_key (err -2)`. Trying to add the driver to the config following xrt_driver approach. 