### PR TITLE
disko-zfs: enable weekly zfs-dedup timer on all hosts

### DIFF
--- a/hosts/ryan.nix
+++ b/hosts/ryan.nix
@@ -22,9 +22,6 @@
   networking.hostName = "ryan";
   disko.rootDisk = "/dev/disk/by-id/nvme-eui.36314130547000630025384100000002";
 
-  # reclaim space from duplicate blocks via block cloning
-  services.zfs-dedup.timer.enable = true;
-
   # 10GbE NICs for network benchmarks:
   # Broadcom BCM57416 NetXtreme-E Dual-Media
   # - e4:3d:1a:72:00:f0

--- a/modules/disko-zfs.nix
+++ b/modules/disko-zfs.nix
@@ -15,6 +15,9 @@
     };
   };
   config = {
+    # reclaim space from duplicate blocks (e.g. docker image layers) via block cloning
+    services.zfs-dedup.timer.enable = true;
+
     disko.devices = {
       disk = {
         vdb = {


### PR DESCRIPTION

Previously only ryan ran the offline dedup timer. All disko-zfs hosts
accumulate duplicate blocks (e.g. from docker's zfs storage driver image
layers), so enable the weekly run cluster-wide and drop the host-specific
override on ryan.
