### PR TITLE
vllm: enable tool calling, IPv6 access and 96k context on jack

### DIFF
--- a/modules/vllm.nix
+++ b/modules/vllm.nix
@@ -13,22 +13,30 @@
         "--served-model-name"
         "qwen3-30b-a3b-instruct"
         "--host"
-        "0.0.0.0"
+        "::"
         "--port"
         "8000"
         "--max-model-len"
-        "32768"
+        "98304"
         "--gpu-memory-utilization"
-        "0.92"
+        "0.94"
+        # Required for OpenAI-style tool/function calling (e.g. coding agents)
+        "--enable-auto-tool-choice"
+        "--tool-call-parser"
+        "hermes"
       ];
-      ports = [ "8000:8000" ];
       volumes = [ "/var/lib/vllm/huggingface:/root/.cache/huggingface" ];
       extraOptions = [
         "--device=nvidia.com/gpu=all"
         "--ipc=host"
+        # Host networking so the API is reachable over IPv6 (retiolum) as well;
+        # docker port publishing without userland-proxy is IPv4-only.
+        "--network=host"
       ];
     };
   };
+
+  networking.firewall.allowedTCPPorts = [ 8000 ];
 
   systemd.tmpfiles.rules = [ "d /var/lib/vllm/huggingface 0755 root root -" ];
 }


### PR DESCRIPTION
The initial vLLM service for Qwen3-30B-A3B-Instruct-2507 was only
reachable over IPv4 because docker port publishing without the
userland-proxy does not cover IPv6 (retiolum). Switch to host
networking and bind dual-stack.

Coding agents need OpenAI-style tool calling, which vLLM rejects
unless a tool-call parser is enabled; use the hermes parser as
recommended for Qwen3.

Raise the context length to 96k (KV cache on the A40 fits ~114k
tokens) and open port 8000 for hosts that do run a firewall.
