### PR TITLE
auto-upgrade: follow nixbot's new outputs attribute names

### DIFF
--- a/modules/auto-upgrade.nix
+++ b/modules/auto-upgrade.nix
@@ -20,17 +20,12 @@
       pkgs.coreutils
       pkgs.curl
     ];
-    # buildbot publishes under checks.<buildPlatform.system>, not the
-    # runtime arch. For native hosts the two coincide, but cross-compiled
-    # boards (ruby/tegan: riscv64 built via pkgsCross on x86_64) would
-    # otherwise look for a riscv64-linux key that never exists. Baking the
-    # build platform in at eval time keeps the URL in lockstep with
-    # flake.nix's machinesPerSystem.
+    # nixbot publishes under default.checks.<buildPlatform.system>, not the runtime arch.
     script = ''
       set -euo pipefail
 
       hostname=$(uname -n)
-      p=$(curl -fsSL "https://buildbot.dse.in.tum.de/nix-outputs/github/TUM-DSE/doctor-cluster-config/master/${pkgs.stdenv.buildPlatform.system}.nixos-$hostname")
+      p=$(curl -fsSL "https://buildbot.dse.in.tum.de/nix-outputs/github/TUM-DSE/doctor-cluster-config/master/default.checks.${pkgs.stdenv.buildPlatform.system}.nixos-$hostname")
 
       if [[ "$(readlink /run/current-system)" == "$p" ]]; then
         echo "Already at $p, nothing to do"


### PR DESCRIPTION
Since the migration from buildbot to nixbot, closures for master are
published as default.checks.<system>.nixos-<host> instead of
<system>.nixos-<host>. The auto-upgrade units kept fetching the old
file names, which were frozen at the last buildbot write (Jul 27), so
hosts like jamie and eliza were 'rolled back' to that stale closure
every day, undoing manual deployments.