### PR TITLE
Enable ccache on irene and steve

### DIFF
--- a/hosts/steve.nix
+++ b/hosts/steve.nix
@@ -6,6 +6,7 @@
     ../modules/nfs
     ../modules/nvidia.nix
     ../modules/vfio/iommu-intel.nix
+    ../modules/ccache.nix
   ];
 
   disko.rootDisk = "/dev/disk/by-id/nvme-SAMSUNG_MZQL23T8HCLS-00A07_S64HNN0XA09313";

--- a/hosts/vislor.nix
+++ b/hosts/vislor.nix
@@ -3,6 +3,7 @@
     ../modules/hardware/poweredge7625.nix
     ../modules/nfs/client.nix
     ../modules/amd_sev_snp-vanilla.nix
+    ../modules/ccache.nix
   ];
 
   disko.rootDisk = "/dev/disk/by-id/nvme-SAMSUNG_MZQL23T8HCLS-00A07_S64HNS0W800676";

--- a/modules/ccache.nix
+++ b/modules/ccache.nix
@@ -1,0 +1,12 @@
+{ config, pkgs, ... }:
+let
+  cacheDir = config.programs.ccache.cacheDir;
+in
+{
+  environment.systemPackages = [ pkgs.ccache ];
+  nix.settings.extra-sandbox-paths = [ cacheDir ];
+
+  # auto-allocate-uids builds run with uids outside `nixbld`, 
+  # so we set it to 1777 and not use programs.ccache.enable.
+  systemd.tmpfiles.rules = [ "d ${cacheDir} 1777 root root -" ];
+}


### PR DESCRIPTION
Useful when rebuilding large C projects while still using flakes.

Show stats:

```
sudo ccache --dir /var/cache/ccache/ -s
```

Change cache size:
```
sudo ccache --dir /var/cache/ccache/ -M 50G
```