### PR TITLE
monitoring: re-enable web UIs behind HTTP basic auth

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -819,6 +819,30 @@ creation_rules:
     path_regex: modules/k3s/secrets.yml$
   - key_groups:
       - age:
+          - age1vfq3px0tw8uflvyuvtw9k7yf0j8gsh06claxk9pqqwujj0vt9dtqyqhx9d
+          - age17n64ahe3wesh8l8lj0zylf4nljdmqn28hvqns2g7hgm9mdkhlsvsjuvkxz
+          - age1nnm255ah9wa4gpsaq0v023a75lnmlcxszt9lc6az3mtwzxgrucfq45rp7h
+          - age1r8v7gf5wxmggsecapn2ptm3q6gjpyquw2fm3dwhr59jpmyjvzcfqd03zcd
+          - age1et533lu2xqnxl5k332f2q57hqxu8j7j4lrzcannqynfmf9xh2azqfzheu4
+          - age1wtek04smdkn5h7nz5x5dtcjpd4l0srxjru6cpk37wgf0aurnc3sspre2e8
+          - age1grsm7z79fd2jyzqxdarwkastyyhghrjcadj5s06akgca704ztcpshx5qcv
+          - age1tpftd5kz59gqahy9e0778wc06qhams6l29zj2n97khekd3ezwyyqthlpr0
+          - age1alt8n4tq5pyn7atrtqmtkhqn9p8aeanxd55pf07ehqp3mhkdfp6qmj2fpd
+          - age17ve9wnwazsmp2xgvsp27u7clywqwwqynsslyyxa4k0hu8mznf5qq2vmp2c
+          - age1mgk6cnl7dmzu6xqs4k7e5epjjg4ygjtjzy9fxqwnw6u8ygtlvpns79zgdk
+          - age1ku5zg6vzgprhavukpj0f8zjsfe2cxl0g4hceljf62hld8t8fguyqp4qtw7
+          - age1qqe0k440aueynmdtyqxrmyhfgw8cs7a3u3xptaazrgvven5gqsmswf3dnf
+          - age1vetu6glcp8md6uqv05jvyyqej47wumswxzjyaadnmuxh89at6sesrxcxzy
+          - age1z6phh2tdqf2cqq435n3gpd58a3zpn0k88zylqu23gxps2hgk8etspg9g30
+          - age17yvfale9tfad8kscjl63kyxzy46vvjg5lvgkfkg924q4vdpxkczqcaj2vx
+          - age1qt20th9n7v0g9tdkhdvp4ztndvnet0nmv303sc68e38s32q965ysl46ns0
+          - age1k4rx2m3mkd7n3ddtvdyjt6kjeyl2vrtkxwj4pqn7x955f9m6gessega7q2
+          - age10504jga9jn7uwlhfx3wusq8ax0xqqxq2zj24r3enr2k6efvwp90qfv53kn
+          - age1dm3shdmfrlhzamy8nrzdqa08azc000x86207lmz2uu35fkfpnu7smg4t4r
+          - age1j7xfwakhq3zdl62gp33h8ptwx8dxzgwpls6jyk8a4tyu89hm84gs32yf30
+    path_regex: modules/monitoring/secrets.yml$
+  - key_groups:
+      - age:
           - age120dyz5upjmv0z4e23vj2dhcm0c5cvm6tmwzl5sj5ye4jrjtwg4tsy3n7m3
           - age1l86ru9amzp3g484wevpa64yjn8ppw0wn2qhud8xz05q84hvq0p0qatqpvq
           - age17n64ahe3wesh8l8lj0zylf4nljdmqn28hvqns2g7hgm9mdkhlsvsjuvkxz

--- a/hosts/doctor.nix
+++ b/hosts/doctor.nix
@@ -35,10 +35,10 @@
     ../modules/borgbackup-repos
     ../modules/buildbot/reverse-proxy.nix
     ../modules/niks3/reverse-proxy.nix
-    # ../modules/monitoring/prometheus # see email to admins from 13.08.2026
+    ../modules/monitoring/prometheus
     ../modules/monitoring/loki.nix
     ../modules/monitoring/telegraf.nix
-    # ../modules/monitoring/grafana-proxy.nix # see email to admins from 13.08.2026
+    ../modules/monitoring/grafana-proxy.nix
     # disabled for now since the download is gone
     #../modules/lrz-gitlab-classroom/frontend.nix
   ];

--- a/modules/monitoring/grafana-proxy.nix
+++ b/modules/monitoring/grafana-proxy.nix
@@ -1,11 +1,21 @@
-{  ... }: {
+{ config, ... }: {
+  sops.secrets.monitoring-basic-auth = {
+    sopsFile = ./secrets.yml;
+    owner = "nginx";
+  };
+
   services.nginx.virtualHosts."grafana.dos.cit.tum.de" = {
     addSSL = true;
     enableACME = true;
+    basicAuthFile = config.sops.secrets.monitoring-basic-auth.path;
     locations."/" = {
       proxyPass = "http://clara.dos.cit.tum.de";
       proxyWebsockets = true;
       recommendedProxySettings = true;
+      # don't let Grafana interpret the basic-auth credentials as a login
+      extraConfig = ''
+        proxy_set_header Authorization "";
+      '';
     };
   };
 }

--- a/modules/monitoring/loki.nix
+++ b/modules/monitoring/loki.nix
@@ -90,7 +90,7 @@ in
           local.directory = "${config.services.loki.dataDir}/ruler";
         };
         rule_path = "${config.services.loki.dataDir}/rules";
-        alertmanager_url = "http://alertmanager.r";
+        alertmanager_url = "http://localhost:9093";
       };
 
       query_range.cache_results = true;

--- a/modules/monitoring/prometheus/nginx.nix
+++ b/modules/monitoring/prometheus/nginx.nix
@@ -10,7 +10,13 @@ let
     proxy_set_header X-Forwarded-Proto $scheme;
   '';
 in
+{ config, ... }:
 {
+  sops.secrets.monitoring-basic-auth = {
+    sopsFile = ../secrets.yml;
+    owner = "nginx";
+  };
+
   security.acme.defaults.email = "joerg.letsencrypt@thalheim.io";
   security.acme.acceptTerms = true;
 
@@ -27,12 +33,14 @@ in
     virtualHosts."prometheus.dse.in.tum.de" = {
       forceSSL = true;
       enableACME = true;
+      basicAuthFile = config.sops.secrets.monitoring-basic-auth.path;
       locations."/".extraConfig = proxy "prometheus";
     };
 
     virtualHosts."alertmanager.dse.in.tum.de" = {
       forceSSL = true;
       enableACME = true;
+      basicAuthFile = config.sops.secrets.monitoring-basic-auth.path;
       locations."/".extraConfig = proxy "alertmanager";
     };
   };

--- a/modules/monitoring/secrets.yml
+++ b/modules/monitoring/secrets.yml
@@ -1,0 +1,197 @@
+monitoring-basic-auth: ENC[AES256_GCM,data:KdblXeNjACwDlwdHCulK4Q1Nd447qkLIDyPGvxcCojFjQWQKLaWn7CAkEtwNDB6ue/GGXNltwgPaL4QUWIskWU/sIX1t0Xul,iv:Czdjw4/BLNldRTo5xYs2OvWc8CRZ5Ql1Fy50CUBJoCM=,tag:JAZNZNkFvboWBhYGiknKgg==,type:str]
+monitoring-password: ENC[AES256_GCM,data:h7GV4rXRw3KWdqDwR5eSn39yE/z/yoTyq7kaGhnqW2E=,iv:3+vz0b/3vbtUp7dq3NpnJjZbjlWJpLnphFWeEtNnx3U=,tag:HY79MRwSVkqf28/dApBkOg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJL1NacC92dHpNbXVPUVht
+            NVlWNG1BUGxkUjRDYy9vVWFBc1Q4SmEwZjFFCmR6OWpTSXNCbE11TFQ0US80Unhz
+            ZklseW1hN0hlS1NSOVJBeUxhYjVpRUEKLS0tIFhhb2QyamQyQ1dWSk1iblBQL29V
+            OVltNzA3NnZubjZ5bmprSlZtN0FzZWcKMvpT5Vfb5HY/4I67iUb3GLoR548eDB46
+            O7cXmfYX+bNP/+ydPK5X9NWrCGVVa/9pnT2jfpmr9aCVdILIfM3gDA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1vfq3px0tw8uflvyuvtw9k7yf0j8gsh06claxk9pqqwujj0vt9dtqyqhx9d
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHdkNDUlFpd3VrTEYwZVgv
+            SzhleUUyN2drM1ViTXdlbHdXeTU1N2R6T0RRClE3eXk0aVpFWVBwSXBzcUJqalk4
+            QzB4SllMM2hmZDZySnRFOGlHcEgxeWcKLS0tICtES095eHdzaDdaR1FsczFzdTN0
+            WkJjenRTM1p0Y1JONWYybjFhVHcvbW8KYu7AkzEVuVlbuS7ubgaeGkIjj6inXjaj
+            nFD8cRB/JflFVuEFO+EVT8zgDrlZppcf2TQ8WonnEFMA4uQqMFMF1A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age17n64ahe3wesh8l8lj0zylf4nljdmqn28hvqns2g7hgm9mdkhlsvsjuvkxz
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDRjQ2cENEdG1DOEJJRC9m
+            Z2Z4THJrdFhGZGdnY1Z6T0hWQ2dxZkM0ekh3ClNYa00xcFpFQ0tjcG8xQm9GVlc3
+            RTJhNU5Dd2JlRUk3UFdtM0ZubDg2TzQKLS0tIFJLaWdKZHlsb29iN3hocEx6MWE4
+            ZWhvS2xuZlRyMW1BU0lqUlA3MWdPR2MKCueMBcbHOzOBBpSnlQGwSwoq8w5k4yYV
+            CI9N+BYJWu/V0uBiQ8fn0xInqGeqI2CxsRbhcOA1Zk0ua5DI6g6X5w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1nnm255ah9wa4gpsaq0v023a75lnmlcxszt9lc6az3mtwzxgrucfq45rp7h
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZYTVpKzBYK2lsSFZBVFlM
+            bFE0cExHNUlnUkZ5Q3UyekpBN2ZLUGtlclFRCnJNWUlxck02NGtqWnF6QmhHZDNL
+            TkFqZzdodDJkdGxvYVc5RTV2QklScG8KLS0tIFlKSTZaaGg4dzVnM1lidGd2amQz
+            cnU5eVY3b0xlcFBjdy9uczhNa1VpK2cKEFTpFzzyGGQGZq05pB9fOeNH3ApD7YIQ
+            axZGJPGx1wB+SpBrs48N7FmHRy1gK/TXHVepDh29CeTqp9aBWq0xVQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1r8v7gf5wxmggsecapn2ptm3q6gjpyquw2fm3dwhr59jpmyjvzcfqd03zcd
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2R3J3YnFuRmZYY1l2cWJ0
+            aTZUSjE2MHhuS3l4Yjlia3NlMERSdG00NWo4CnBmRTBvblZzcnlsM1ArdFZJSExt
+            V29Bb1k2TTRXVjNPZGE2VlFaeVRnRHcKLS0tIDhxNlgwenMzenIvWU1YU2VFNTN5
+            SnJpZWN0S3U5cVg1Tyt0aUFiSEdFelkKsYEXYbrvY5m//eEqDc26sZXl4b62ange
+            MZQL72tnHL/9xHPeoTa8WCNuxepnREwWQi96ki6//+8VI6N9DSMznA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1et533lu2xqnxl5k332f2q57hqxu8j7j4lrzcannqynfmf9xh2azqfzheu4
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhRm92dXdHR3E5NUJjRjRF
+            dk5ZUFFUcC8vMjJDdVBZaG92NHBiaTFiRGpBCjh0RGhFNFVFUFZTdTFWUTBKMDZo
+            bFRXK29TMkFldFJjc1VqR0pienJaSUkKLS0tIER5cG5TVkZFRlZ2bCtndTFhUHY1
+            emdqNHZvTTlvYzA0Z0ZEWk94b3FEbTAKPdW+8ED9PcWGsTmGVoLW8PE4CiO8xfGf
+            dUc9Rfe5Kp+URq0O0bHET1aZRDxu4AVBzcEWetNwtH/1l+pS5kh1+w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1wtek04smdkn5h7nz5x5dtcjpd4l0srxjru6cpk37wgf0aurnc3sspre2e8
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUZ21nV3N4bTRGT0s1SDVI
+            NzdQaEIzR01IT3g3d25yNm93bUFSU1Z6VVFRCjhVTlN4OEx3RzJTdGJ5VjQ1OGlC
+            bmRncnlNbi9oS0xTcTNxQXZBdm93dkUKLS0tIHp1N3FscXZMQ0t6Zy91encwdUxQ
+            UnZRZkgzTldTcXUvMThQWkw5UTVPSmsKhO2br5vRt7eFm3hCDWLuwom36Kb27or4
+            7j2k/tUZ6j0lq4ZaP3AF1fBbBuAwm5vyqcNdlE+mV6aoowh4ocm9mQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1grsm7z79fd2jyzqxdarwkastyyhghrjcadj5s06akgca704ztcpshx5qcv
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtam5JbzNiaGtBNTRNbXll
+            MC9uVVZVYXZPMjZSb05jZTdRNHBqVzRkWHhVCllLVWtndHY2bmZLQlpHajBiOEpn
+            VVZ2bjg1Q2xGaCt6MVF3VUJ0czVIbGsKLS0tIHRQRjh1Q3VYcWJldDBoU1c5UEZC
+            UVN4VXhnYnNUbGExTyswdVJHeTRiUjAKgQR0Gp30/xP4Y6Nlb8VGkonnUuayx+Rc
+            VsIEkbcGGGh3DHVKpZYg3e9Sibulq8G6+YHjrrMuSpqP+pK8zZmoag==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1tpftd5kz59gqahy9e0778wc06qhams6l29zj2n97khekd3ezwyyqthlpr0
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnMG1XTjdGUURGRyt6cGV1
+            L211Q2paZkkybmU5eHJPemFBMXlxUEMxOGg4Cm1BY2tNcXA5QWJKRldYSDZtMVFJ
+            cXdzUHN2ekdySTNpVFlNV1NHVGxnNlEKLS0tIEJRcUFKVzFNaFVaK2d5QlNSUWY5
+            a015Nnd3NzJjQ3gvbEpqNGhzbTJMNE0Ksbl9viwTIosZpw/bOdxKl8yLVHD4iror
+            +l3jnSFvS6x/fITljpqBMgbXvhIfily16HwEXQWsJwgHVn+0mBuY/A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1alt8n4tq5pyn7atrtqmtkhqn9p8aeanxd55pf07ehqp3mhkdfp6qmj2fpd
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3QWZmNlM1ekVPS3JIUnJ0
+            SG5RV3U4SGFmRWVra29sMEFXejA0OEgvd2lJCnBYQWdZZEp2WkFxYkJzdGVWZy9n
+            RUMyeDdxSi9zaEwyZ01pbm8ycVlzZEkKLS0tIFduK2NoVVJxN2ZvTU5OV3BIOXZv
+            eHRMZzQ2R2hyTno2cFd6V0FmbFF2Y0UKTLN38aZMLa2wIb/moOBy0Wh8/OyvTDXb
+            2gKEDYM3vGFz2dPchsg6g3KaHaNyqx7eCMARsQKPWaXS/Yf39qlmfg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age17ve9wnwazsmp2xgvsp27u7clywqwwqynsslyyxa4k0hu8mznf5qq2vmp2c
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBraDMzMXR2V0hmTG9ZZXZQ
+            cytIdDdjQ1VDTTVJMkdRcXRkQ09ueUM3ZEI0CkVKVUpYa24yV3ovNGprZXdOZ3I3
+            VnJKTTNOWHpGTWRER00yKy9sL2pWdUkKLS0tIDRvUmRqVUs5My8zc1VHeHdBZ2I4
+            VkZLdjlkKzlTbVpseFhBVlhPTXE5NWMKG6ofMHW7o00lO43qCgaJoTlqiX8nEvRD
+            fnXjTHQxxc3otVfRLZP8rRmDSZoLfhyWzw/fMGyDTCPu2Ui5JN4k3g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1mgk6cnl7dmzu6xqs4k7e5epjjg4ygjtjzy9fxqwnw6u8ygtlvpns79zgdk
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyNjhJVllLRitENENOOXpM
+            aEhpVW51bXFFekh6VmVoUmxpbm9ZVlI0UHgwCmllb09ZQzZFRTBLVzE2VjFCeEdk
+            YUZFMW9NMWxQVENRRUx0VkJURkZxREEKLS0tIDdKK3cxbWU5bkt2Ung4bGk3QWJz
+            c0pmaVhFRmgwTlNoOWpidDc5Q1RRUjQKbgp7Y6rVWcl9/Sio6e3u84IXjCETTSvX
+            QOf8eAptNNNYHHgCng4rmRh4i5COzNDnmIi/H7Sro8i+na7uX8I81A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ku5zg6vzgprhavukpj0f8zjsfe2cxl0g4hceljf62hld8t8fguyqp4qtw7
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhZkwyQ3ZDdzFoN0VOUXRC
+            WUtRWVZCR2NmU3RSdGpDam1HeDNZQ3U4c1JFCmpGOEliR3ZYczN2RE5pem9nNmt4
+            emRqS0VwVVIxOGl5UGI0THA3V3VEaG8KLS0tIHRjT3Vjb3lMVCt4aFVMWG5xUVZ6
+            YlRsbGhDQytXT0FWMjF2aFFMM0I1UUkK/6Frm+9lN1CcjbaRiRPpiXmz1tJFtcCk
+            yTX7X82R9FOvTgzA2ix8/K17XELkk8+o4hTS0zyuPcl8oyZJ93yOwg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1qqe0k440aueynmdtyqxrmyhfgw8cs7a3u3xptaazrgvven5gqsmswf3dnf
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxWHB2WjBqdFhqUU1zbU9t
+            VzRNZEl2Rml2TE1sZ3FEek0rMDdoVVdvZldnCjdDUHgxWkp6SmpUSGJqY2k3NjFG
+            WUZmdDFWc3ExZ2R4blBlYS93WXIzS2cKLS0tIGxJZkw3cVRMYnFxUnpsL3orMThr
+            MUs5ZnlnaWk0dG9BSWFFZU9QSzZFaHcKvCyZ7gU8+GnBeiRlkvaeXIH/1EbR0Wlq
+            laBtlNyDXr9jhjYYl6CUeL9uyRJNDqytqRiksc4y7j99vj8GgbLstg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1vetu6glcp8md6uqv05jvyyqej47wumswxzjyaadnmuxh89at6sesrxcxzy
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFMDdYVmtYcmNNNzd2VDlx
+            S0diQmJVSzZIQzA5S2tTWDhHaFFOVStzbWpBCmUrbWZCS2tQb2tma0lyRWpmeDJa
+            cVcrMk5CVTdwQWJmc2lTUjdpUWttSTgKLS0tIFRqYjVkbkJMMmxxeStnMEdDZXBI
+            KzR1ZTZQODRLOFk4M1RVM1lvcE5IVmcKQu2gzlT/i21J3zvfvGTungK1xL/PS5mv
+            xd+c8dSDmUoRNGmuglD1WiA8BDNppH0bN8S/c4/AA3iIsB6CMc4oGg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1z6phh2tdqf2cqq435n3gpd58a3zpn0k88zylqu23gxps2hgk8etspg9g30
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrRWVhcVRKVks4TTJtaG1l
+            WnJRTFhmaWo5MFF6V1BYK00wU0pCYVRpdFRjCmtCeitoQjdMNEc2V3cwMnRVUVJ4
+            ZDV3WEVNYlhaRjdIbitSUlNmc0xYSE0KLS0tIE90dGdYSFpoLzR5WlNaQUlENzFT
+            QS9HRnMvclg4SXRoUFM5cDVJNkNlc0UKCK8AE0yD0QZYkOEgR2DkxnTfyJOEMoKM
+            2JkmifIDStjWNreVpR82SRJobkTtLCNk2KwT1UjG55zEvkdbkagvrg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age17yvfale9tfad8kscjl63kyxzy46vvjg5lvgkfkg924q4vdpxkczqcaj2vx
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNaU5sM2tYNkdVNjVrR0Rw
+            YjNYT0JaTnlORFJ2SHgrNnVReXZRekJxbWtnCjNZM2pFanVWOVlZNWdNT0VrTTlB
+            aTB6bitqTEU4em43UEd4WGVUT1hxUFkKLS0tIHVXNXA1NWZhU1o5K045cFRocnEv
+            VUhzNzl2bUNBY1N5eE1ib2JHeGwwcWcK3jJIoIhNLZujizJIda4diirKAW0x1hZG
+            jxmScjxLtT74Ev3SmWh5nbTCbwYJrE++e4y55Q/fBu330nXmTK63uA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1qt20th9n7v0g9tdkhdvp4ztndvnet0nmv303sc68e38s32q965ysl46ns0
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTTXFqbTlzU0JpMGlJTXE2
+            ZWQxMnk4bmw3M2pVTFNMNVlyTVJQVDdmZ1ZzCkF2dEpIdFpMalkwUHF5dldBTGFr
+            ZVdFWitEOGYvTExKdjQ5OHRzWkZnQ0kKLS0tIDBXb3pYeEdLVWhwdldUbWU0YUpm
+            akhqclRRaWVsOTJJeVdLa2FId1ByOUkK4jxnuxIglyOma4CrtlqKDqJm66FPLrnJ
+            hGtwxzFhx5ZDqsAGeUmllbSCqczmVfROw1YuS7pq43htJBwSVtE7Fg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1k4rx2m3mkd7n3ddtvdyjt6kjeyl2vrtkxwj4pqn7x955f9m6gessega7q2
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBock15S2RZSWY4ZWlwYXhp
+            dERRL3hlOFBENkQxcmQ0NGhGU3BhWFVFQmprCkEzZ2RaS0dhbUZRTmZYTUdUWHp6
+            UTR6YmJjOVdkayt6Lys4WnJITGs0ZzgKLS0tIEQ2NTBraHh5VWF1MTRabWtnTE1j
+            a0g1eGhnamVhUkliOHNKSXBWMklDWmcK4BB5Mbm8SUycMrwGaCJ3cprdGkYTwaxY
+            CDWJT7/59xRZbPA6ENZsfppPZBJtyhHb6AVcBMlkZE1NTy72IRdRuw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age10504jga9jn7uwlhfx3wusq8ax0xqqxq2zj24r3enr2k6efvwp90qfv53kn
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTR3hRK3ljS1dCazNpeHQ2
+            ejdEaUZQRC9sWFZMT25QVUl6aHF6THlRa2xJCnVYSGN6UHZjQ1cwMDJieEhybWpP
+            SlU5amlKUnVxb0pXQWRyZkdjcXd1Y00KLS0tIHNNM0FNV2pza1RSSEJNUndDK0Zh
+            eTlROVFLTFNienRUYW1vUzd3MHdWWG8KEtNh7oWLUlW/efmmZ6v8tiAw53hXE5Jp
+            SSdCcliBLcbOQx8OKsggbR4NtPG2BZw2nQ6pQNRtL2/ph5koLpZDrQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1dm3shdmfrlhzamy8nrzdqa08azc000x86207lmz2uu35fkfpnu7smg4t4r
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByRzhncnFlVjhtRnExSWhU
+            YmtWYzNFMkdQTHhzOXJBN21CTEhuaUVVR200CnREMjczRitNblQ1ZlcvZ1FQZnU3
+            WjFvZUVRaVk4YTRxaExYL3NncHU5NlkKLS0tIDJ0ZVZDTSsweUxPRTJpc0dubXpU
+            VU9Eb2V2dWJScHh2WkcvMnpLSU53OE0Kim271zY+3H6w6G+auPsWXRQFZDENNs8X
+            zfvzN4I9Ima9zfarZcen2YznxCsKgik51ZQrd7h9bnpUfQDfEcWY5g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1j7xfwakhq3zdl62gp33h8ptwx8dxzgwpls6jyk8a4tyu89hm84gs32yf30
+    lastmodified: "2026-08-17T08:05:47Z"
+    mac: ENC[AES256_GCM,data:eQC3ODEHW8NkHi0vblkMSAkNQT6MwwSOjsIrUAAsHXVJWU4ocACy3tEtBQJioT8sMu2jXmZ9kNHeZcQ11jaNWloO62tfSDNC8DEWB/hS66r8KG2yuRSXON1JC+BqgFe/hEUHOm8kPzi3MrTgL5eeiPZQ1J/6JfW3PQx2jKWqhIU=,iv:gqnVMeqmdL/+THYlGybSSyAl/0hTk6LYATuC5sCrOos=,tag:XtYbxDQGy5dL5nYSuP0R6Q==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.2

--- a/sops.yaml.nix
+++ b/sops.yaml.nix
@@ -62,6 +62,7 @@ let
       "modules/nfs/secrets.yml$" = [ "mickey" "dan" ];
       "modules/k3s/secrets.yml$" = [ "astrid" "mickey" "dan" ];
       "modules/niks3/secrets.yml$" = [ "astrid" "doctor" "graham" ];
+      "modules/monitoring/secrets.yml$" = [ "doctor" ];
 
       "modules/users/xrdp-passwords.yml$" = [
         "amy"


### PR DESCRIPTION

The prometheus, alertmanager and grafana proxies were disabled because
they were publicly reachable without authentication (see email to admins
from 13.08.2026). Guard them with a shared htpasswd secret so they can
be exposed again.

Ingestion is unaffected: prometheus scrapes outbound, loki already has
its own basic auth, and loki's ruler now reaches alertmanager via
localhost instead of the now-authenticated nginx vhost.
