### PR TITLE
tribuchet: bump for chunk size bound

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -621,11 +621,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787638136,
-        "narHash": "sha256-xglMWWuBy8CfWpASs59Xs0FEj1V5HZcWR4lM5SjzZdM=",
+        "lastModified": 1787642300,
+        "narHash": "sha256-hjSDbMeVN4bopcKLOnk9xG+pB8xaYmNI/Q33NfE6Vu8=",
         "owner": "Mic92",
         "repo": "tribuchet",
-        "rev": "41405c78eba5efa188a5954818a21a612dfd7f59",
+        "rev": "781f6f77134092bdf3c84ac0b6c93ea23e15e4a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Hub, workers and attach clients must run the same protocol.