### PR TITLE
monitoring: stop using 6.<host>.r aliases

### DIFF
--- a/modules/monitoring/http-sd-generate.py
+++ b/modules/monitoring/http-sd-generate.py
@@ -98,7 +98,7 @@ def main() -> None:
             [
                 "[[inputs.ping]]",
                 '  method = "native"',
-                f'  urls = ["6.{host}"]',
+                f'  urls = ["{host}"]',
                 "  ipv6 = true",
                 "  [inputs.ping.tags]",
                 f'    org = "{org}"',


### PR DESCRIPTION

kartei no longer generates 6.-prefixed aliases in /etc/hosts, so every
IPv6 ping target from doctor became NXDOMAIN. <host>.r resolves to the
retiolum v6 address; ipv6 = true keeps the check on the v6 path.
