### PR TITLE
flake.lock: bump tribuchet to match hub protocol

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -319,11 +319,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785389976,
-        "narHash": "sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU=",
+        "lastModified": 1786845137,
+        "narHash": "sha256-oQFip+v0luP8NIxJzmiW4Wu8bILsbFWom5l0zonl8hQ=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "15abb8c98f336cd8bd840d71059adebabe60bf04",
+        "rev": "4cff07de74b50e64bdd68cd4e722ab5b6b35ee48",
         "type": "github"
       },
       "original": {
@@ -621,11 +621,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787642300,
-        "narHash": "sha256-hjSDbMeVN4bopcKLOnk9xG+pB8xaYmNI/Q33NfE6Vu8=",
+        "lastModified": 1787653168,
+        "narHash": "sha256-/Q0LuV8gmdkoTAcDjSM/Wn8+xjJf9+Hf7Zuic8y9mI8=",
         "owner": "Mic92",
         "repo": "tribuchet",
-        "rev": "781f6f77134092bdf3c84ac0b6c93ea23e15e4a5",
+        "rev": "0a55e140decca08303fa9ca6ceb028690c1ac6b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The hub on eve runs a build with the chunked transfer protocol
(0ae455a). Workers built from the old lock register with empty
capabilities, so the hub advertises no systems to nix and
aarch64-linux builds fail with 'Failed to find a machine'.
