### PR TITLE
bump nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -441,10 +441,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786899015,
-        "narHash": "sha256-EMh/O/P5ZCH0YuG/oZSkZgxJ0ehvJcPc5E6yWaGebmc=",
+        "lastModified": 1787516701,
+        "narHash": "sha256-1gCfrG8Y+aBRdNNVc+PxhJjXy6roUEjsEG7K+I3uLCQ=",
         "ref": "nixos-26.05-backports",
-        "rev": "a56f5cf1d2b6888c319e7cd3b2c88d08c706c06e",
+        "rev": "c8ca0d8941ec0271472dbda7c887305c970fe5ea",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/TUM-DSE/nixpkgs.git"

--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787504431,
-        "narHash": "sha256-O+m4xtZR+z0Rhx1OsCFRHhavWosap3ii3JVFfkyoLOI=",
+        "lastModified": 1787791704,
+        "narHash": "sha256-lKN0sjSFOfqcgTY1Etya1f/PqjCtAjzJKNjz0Vy0bxw=",
         "owner": "Mic92",
         "repo": "nixbot",
-        "rev": "d0cd0f2b94c18be22455a183fc5e561e915de776",
+        "rev": "f8736e3221601ce8a90ae5c88581ac80578d1412",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787791704,
+        "lastModified": 1787791768,
         "narHash": "sha256-lKN0sjSFOfqcgTY1Etya1f/PqjCtAjzJKNjz0Vy0bxw=",
         "owner": "Mic92",
         "repo": "nixbot",
-        "rev": "f8736e3221601ce8a90ae5c88581ac80578d1412",
+        "rev": "8922da2683f10ff4818c2649a323f558b793edc4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -441,10 +441,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787516701,
-        "narHash": "sha256-1gCfrG8Y+aBRdNNVc+PxhJjXy6roUEjsEG7K+I3uLCQ=",
+        "lastModified": 1787790961,
+        "narHash": "sha256-+q0MOt6eSCYNeR1QPbNKcsHWw8aTGjSNObquffi6DRg=",
         "ref": "nixos-26.05-backports",
-        "rev": "c8ca0d8941ec0271472dbda7c887305c970fe5ea",
+        "rev": "a28291c0882ea4c451cc196f1daa3688197369d3",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/TUM-DSE/nixpkgs.git"

--- a/modules/amd_sev_snp-vanilla.nix
+++ b/modules/amd_sev_snp-vanilla.nix
@@ -1,8 +1,8 @@
-{ pkgs, lib, ... }:
+{ pkgs, ... }:
 {
-  # Use 6.16 (or newer) kernel
-  boot.kernelPackages = lib.mkForce pkgs.linuxPackages_latest;
-  boot.zfs.package = pkgs.zfs_unstable; # needed for 6.9
+  # srvos' latest-zfs-kernel mixin picks the newest kernel this zfs supports
+  # (>= 6.16 needed).
+  boot.zfs.package = pkgs.zfs_unstable;
 
   boot.kernelPatches = [
       {

--- a/modules/intel_tdx.nix
+++ b/modules/intel_tdx.nix
@@ -1,7 +1,8 @@
 { pkgs, lib, ... }:
 {
-  boot.kernelPackages = lib.mkForce pkgs.linuxPackages_latest;
-  boot.zfs.package = pkgs.zfs_unstable; # needed for 6.18
+  # srvos' latest-zfs-kernel mixin picks the newest kernel this zfs supports
+  # (>= 6.18 needed for TDX kexec).
+  boot.zfs.package = pkgs.zfs_unstable;
 
   boot.kernelPatches = [
     {


### PR DESCRIPTION
- **bump tribuchet**
- **flake.lock: bump nixpkgs (nixos-26.05-backports a56f5cf -> c8ca0d8)**
