### PR TITLE
flake.lock: bump tribuchet

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -621,11 +621,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787653168,
-        "narHash": "sha256-/Q0LuV8gmdkoTAcDjSM/Wn8+xjJf9+Hf7Zuic8y9mI8=",
+        "lastModified": 1787729940,
+        "narHash": "sha256-yYvNh+JtAGa23fLabg6bsTQlsIYrTV27kqQbGjF6Gu8=",
         "owner": "Mic92",
         "repo": "tribuchet",
-        "rev": "0a55e140decca08303fa9ca6ceb028690c1ac6b1",
+        "rev": "4ade04c915f7ffb7bd8f1514439bda1f5e2ce440",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Picks up Mic92/tribuchet#116 (single wait mechanism for import
references); eliza's worker hung in input import with the old code.
