### PR TITLE
auto-upgrade: follow nixbot's checks.<system> output names

### DIFF
--- a/modules/auto-upgrade.nix
+++ b/modules/auto-upgrade.nix
@@ -20,12 +20,12 @@
       pkgs.coreutils
       pkgs.curl
     ];
-    # nixbot publishes under default.checks.<buildPlatform.system>, not the runtime arch.
+    # nixbot publishes under checks.<buildPlatform.system>, not the runtime arch.
     script = ''
       set -euo pipefail
 
       hostname=$(uname -n)
-      p=$(curl -fsSL "https://buildbot.dse.in.tum.de/nix-outputs/github/TUM-DSE/doctor-cluster-config/master/default.checks.${pkgs.stdenv.buildPlatform.system}.nixos-$hostname")
+      p=$(curl -fsSL "https://buildbot.dse.in.tum.de/nix-outputs/github/TUM-DSE/doctor-cluster-config/master/checks.${pkgs.stdenv.buildPlatform.system}.nixos-$hostname")
 
       if [[ "$(readlink /run/current-system)" == "$p" ]]; then
         echo "Already at $p, nothing to do"


### PR DESCRIPTION

nixbot stopped writing default.checks.<system>.* on 2026-08-18 and now
publishes checks.<system>.*. The stale files were still served, so every
host re-applied the 08-18 closure daily, rolling back newer deploys
(eliza gens 275/278/283/287). Stale files on graham have been removed so
a future rename yields a curl 404 instead of a silent downgrade.
