### PR TITLE
monitoring: send authelia/grafana mail via the host's postfix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -158,7 +158,7 @@ machines. Those machines also are not backed up.
 - RBG VMs:
   - dosvm5.cit.tum.de (ubuntu VM itself), doctor.dos.cit.tum.de (nixos container in VM) [doctor.nix](../hosts/doctor.nix): borg backup target, monitoring
     - [grafana](https://grafana.dos.cit.tum.de) - login with your RBG/CIT account (same as for login.dos.cit.tum.de, not the TUM-ID). Only users with `citLogin` set in modules/users/*.nix are allowed; dosvm5 admins get grafana admin
-    - prometheus/alertmanager are behind [authelia](https://auth.dos.cit.tum.de): CIT/RBG LDAP password or passkey. The one-time code needed to register a passkey lands in `/var/lib/authelia-main/notifications.txt` on doctor.
+    - prometheus/alertmanager are behind [authelia](https://auth.dos.cit.tum.de): RBG/CIT password or passkey (register one under auth.dos.cit.tum.de → settings; the confirmation code is mailed to your CIT address)
     - SSHing into the nixos container that runs all services: use the login.dos.cit.tum.de jumphost as usual, but ssh on doctor.dos.cit.tum.de uses port 2222!
     - [prometheus](https://prometheus.dos.cit.tum.de) - see [monitoring.md](./monitoring.md) for adding machines
     - [alertmanager](https://alertmanager.dos.cit.tum.de)

--- a/modules/monitoring/authelia.nix
+++ b/modules/monitoring/authelia.nix
@@ -113,9 +113,13 @@ in
           }
         ];
         storage.local.path = "/var/lib/authelia-main/db.sqlite3";
-        # No SMTP relay yet: the one-time code for registering a passkey ends up
-        # here, so an admin has to hand it out (`tail /var/lib/authelia-main/notifications.txt`).
-        notifier.filesystem.filename = "/var/lib/authelia-main/notifications.txt";
+        # postfix on the Ubuntu host (shared netns) relays via mailrelay.cit.tum.de
+        notifier.smtp = {
+          address = "smtp://127.0.0.1:25";
+          sender = "DSE monitoring <authelia@dosvm5.cit.tum.de>";
+          disable_require_tls = true;
+          disable_starttls = true;
+        };
 
         access_control = {
           default_policy = "deny";

--- a/modules/monitoring/grafana.nix
+++ b/modules/monitoring/grafana.nix
@@ -76,6 +76,14 @@ in
         config_file = toString ldapConfig;
       };
       "auth.anonymous".enabled = false;
+      # postfix on the Ubuntu host, see authelia.nix
+      smtp = {
+        enabled = true;
+        host = "127.0.0.1:25";
+        from_address = "grafana@dosvm5.cit.tum.de";
+        from_name = "DSE monitoring";
+        skip_verify = true;
+      };
       analytics = {
         reporting_enabled = false;
         check_for_updates = false;

--- a/modules/monitoring/nspawn.yml
+++ b/modules/monitoring/nspawn.yml
@@ -14,6 +14,12 @@
         update_cache: yes
         cache_valid_time: 86400
 
+    # RBG image ships postfix on 127.0.0.1:25 relaying via mailrelay.cit.tum.de;
+    # authelia in the container uses it (shared netns).
+    - name: Local mail relay
+      apt:
+        name: postfix
+
     # shared netns: the container runs its own rpcbind/statd for the NFSv3 borg mount
     - name: No rpcbind on the host
       apt:


### PR DESCRIPTION
The RBG Ubuntu image ships postfix on 127.0.0.1:25 relaying through
mailrelay.cit.tum.de; the container shares the netns, so passkey
enrollment codes and grafana notifications can go out by mail instead
of landing in a file on disk.
