### PR TITLE
use linux_latest on all hosts to avoid bnxt_en breakage in 6.18.45

### DIFF
--- a/configurations.nix
+++ b/configurations.nix
@@ -65,6 +65,12 @@ let
       # not need to force-import the root pool. Silences the 26.11 deprecation
       # warning and follows the upcoming default.
       boot.zfs.forceImportRoot = false;
+
+      # Let mixins-latest-zfs-kernel pick linux_latest instead of the LTS
+      # kernel. linux 6.18.45 breaks bnxt_en (page_pool_create_percpu()
+      # fails with -EINVAL, NIC never comes up) which took eliza, mickey,
+      # astrid and dan offline; 7.1.x is known good on amy/clara/ian.
+      boot.zfs.package = pkgs.zfs_unstable;
     })
     kartei.nixosModules.retiolum
   ];

--- a/flake.lock
+++ b/flake.lock
@@ -138,6 +138,28 @@
         "type": "github"
       }
     },
+    "fenix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "tincr",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src_2"
+      },
+      "locked": {
+        "lastModified": 1787208815,
+        "narHash": "sha256-SiyWmwDoDF2jCEpEW887qxaUazaQrVQs+QXq2bvgm+0=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "428f69c19e46334bed722164c5125b62d3722723",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -500,6 +522,23 @@
         "type": "github"
       }
     },
+    "rust-analyzer-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787106123,
+        "narHash": "sha256-Usi0dFNYgdN5gXYDjLLGCYYkzW7Xl9uBhwGD5OkuWoM=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "32a3346dff5b26e16227affd5af933e15ebc598b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
     "sops-nix": {
       "inputs": {
         "nixpkgs": [
@@ -545,6 +584,7 @@
         "crane": [
           "crane"
         ],
+        "fenix": "fenix_2",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -553,11 +593,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787218720,
-        "narHash": "sha256-NjbFf8aeeq/UwJbXQDhdIDKKbx2lZNtlP2N9PNYIfdg=",
+        "lastModified": 1788080144,
+        "narHash": "sha256-bbcp5fOPimxXR4KQPfv2qNVOa2sqaXB7YNHPoG19bPI=",
         "owner": "Mic92",
         "repo": "tincr",
-        "rev": "265a084383b28fd5a6ad675bcd14e4bf50ed874d",
+        "rev": "3277b0821d119480f8a1567a4c11903e9dfd6587",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -138,28 +138,6 @@
         "type": "github"
       }
     },
-    "fenix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "tincr",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src_2"
-      },
-      "locked": {
-        "lastModified": 1787208815,
-        "narHash": "sha256-SiyWmwDoDF2jCEpEW887qxaUazaQrVQs+QXq2bvgm+0=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "428f69c19e46334bed722164c5125b62d3722723",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -522,23 +500,6 @@
         "type": "github"
       }
     },
-    "rust-analyzer-src_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1787106123,
-        "narHash": "sha256-Usi0dFNYgdN5gXYDjLLGCYYkzW7Xl9uBhwGD5OkuWoM=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "32a3346dff5b26e16227affd5af933e15ebc598b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
     "sops-nix": {
       "inputs": {
         "nixpkgs": [
@@ -584,7 +545,10 @@
         "crane": [
           "crane"
         ],
-        "fenix": "fenix_2",
+        "fenix": [
+          "hosthog",
+          "fenix"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ],

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,7 @@
     tincr.inputs.nixpkgs.follows = "nixpkgs";
     tincr.inputs.treefmt-nix.follows = "treefmt-nix";
     tincr.inputs.crane.follows = "crane";
+    tincr.inputs.fenix.follows = "hosthog/fenix";
 
     tribuchet.url = "github:Mic92/tribuchet";
     tribuchet.inputs.crane.follows = "crane";

--- a/modules/amd_sev_snp.nix
+++ b/modules/amd_sev_snp.nix
@@ -1,10 +1,7 @@
-{ pkgs, ... }:
 {
   # SEV-SNP host support is upstream since 6.11 and the required config
   # options (AMD_MEM_ENCRYPT, KVM_AMD_SEV, CRYPTO_DEV_CCP*, VFIO_DEVICE_CDEV)
   # are enabled in the stock nixpkgs kernel, so no rebuild is needed.
-  # srvos' latest-zfs-kernel mixin picks the newest kernel zfs_unstable supports.
-  boot.zfs.package = pkgs.zfs_unstable;
 
   boot.kernelParams = [
     "kvm_amd.sev=1"

--- a/modules/intel_tdx.nix
+++ b/modules/intel_tdx.nix
@@ -1,9 +1,5 @@
-{ pkgs, lib, ... }:
+{ lib, ... }:
 {
-  # srvos' latest-zfs-kernel mixin picks the newest kernel this zfs supports
-  # (>= 6.18 needed for TDX kexec).
-  boot.zfs.package = pkgs.zfs_unstable;
-
   boot.kernelPatches = [
     {
       name = "tdx-config";


### PR DESCRIPTION
6.18.45 breaks bnxt_en (page_pool_create_percpu -EINVAL); eliza/mickey/astrid/dan lost network after reboot. amy/clara/ian on 7.1.x are fine, so use zfs_unstable + latest kernel everywhere.