### PR TITLE
irene: bind dead KIOXIA nvme to pci-stub

### DIFF
--- a/hosts/irene.nix
+++ b/hosts/irene.nix
@@ -19,6 +19,11 @@
   };
   powerManagement.cpuFreqGovernor = "performance";
 
+  # Dead KIOXIA CM7-R (#1796). Keep nvme off it. Hot-removing it resets the machine.
+  boot.initrd.services.udev.rules = ''
+    ACTION=="add", SUBSYSTEM=="pci", KERNEL=="0000:c5:00.0", ATTR{vendor}=="0x1e0f", ATTR{driver_override}="pci-stub"
+  '';
+
   system.stateVersion = "22.11";
   simd.arch = "znver4";
   services.envfs.enable = true;


### PR DESCRIPTION
The CM7-R at 0000:c5:00.0 fails every command with Internal Error and spams the log. Keep the nvme driver off it until the drive is pulled. See #1796.