### PR TITLE
wilfred: bind onboard X550 ports to pci-stub

### DIFF
--- a/hosts/wilfred.nix
+++ b/hosts/wilfred.nix
@@ -21,4 +21,9 @@
   system.stateVersion = "21.11";
 
   networking.doctor-bridge.enable = true;
+
+  # Onboard X550 (eno1/eno2) tx-hang loop panics the kernel (#1798). Keep ixgbe off it.
+  boot.initrd.services.udev.rules = ''
+    ACTION=="add", SUBSYSTEM=="pci", KERNEL=="0000:01:00.[01]", ATTR{vendor}=="0x8086", ATTR{driver_override}="pci-stub"
+  '';
 }


### PR DESCRIPTION
eno1 sits in an ixgbe tx-hang/reset loop that ends in a panic in ixgbe_read_reg and takes the host down, on both 6.18.45 and 7.1.9. See #1798.