### PR TITLE
tribuchet: run the worker as a flakelet

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "adios": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772186395,
+        "narHash": "sha256-NshyMZYZwjKMLKEX0eDf9Fcekq8MFNFk02wW5knzlZU=",
+        "owner": "adisbladis",
+        "repo": "adios",
+        "rev": "6a54071689ec9ec784a16e4eec8ddb864eca2982",
+        "type": "github"
+      },
+      "original": {
+        "owner": "adisbladis",
+        "repo": "adios",
+        "type": "github"
+      }
+    },
     "coyote": {
       "flake": false,
       "locked": {
@@ -174,6 +190,27 @@
         "type": "github"
       }
     },
+    "flakelet": {
+      "inputs": {
+        "adios": "adios",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788292392,
+        "narHash": "sha256-f/06YkoGOsJq9msglQKMJyzK3rQYmPVFhyN0y1FsHLU=",
+        "owner": "Mic92",
+        "repo": "flakelet",
+        "rev": "5ce75ca90e28cf84b66ea40eacc3b0d1c7f06b3f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "flakelet",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -303,27 +340,6 @@
         "owner": "nix-darwin",
         "repo": "nix-darwin",
         "rev": "15abb8c98f336cd8bd840d71059adebabe60bf04",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-darwin",
-        "repo": "nix-darwin",
-        "type": "github"
-      }
-    },
-    "nix-darwin_2": {
-      "inputs": {
-        "nixpkgs": [
-          "tribuchet",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786845137,
-        "narHash": "sha256-oQFip+v0luP8NIxJzmiW4Wu8bILsbFWom5l0zonl8hQ=",
-        "owner": "nix-darwin",
-        "repo": "nix-darwin",
-        "rev": "4cff07de74b50e64bdd68cd4e722ab5b6b35ee48",
         "type": "github"
       },
       "original": {
@@ -464,6 +480,7 @@
         "fast-nix-gc": "fast-nix-gc",
         "flake-parts": "flake-parts",
         "flake-registry": "flake-registry",
+        "flakelet": "flakelet",
         "home-manager": "home-manager",
         "hosthog": "hosthog",
         "jetpack-nixos": "jetpack-nixos",
@@ -479,7 +496,6 @@
         "srvos": "srvos",
         "tincr": "tincr",
         "treefmt-nix": "treefmt-nix_2",
-        "tribuchet": "tribuchet",
         "zfs-dedup": "zfs-dedup"
       }
     },
@@ -608,33 +624,6 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "tribuchet": {
-      "inputs": {
-        "crane": [
-          "crane"
-        ],
-        "nix-darwin": "nix-darwin_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "treefmt-nix": [
-          "treefmt-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787858127,
-        "narHash": "sha256-UtSTRLO5zR+YMED4zx+XVbe2SHbsuWJ7CKup5AJCFuY=",
-        "owner": "Mic92",
-        "repo": "tribuchet",
-        "rev": "261d795b8d18bfdb1f398d8faa90434da5970be6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Mic92",
-        "repo": "tribuchet",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -61,10 +61,8 @@
     tincr.inputs.crane.follows = "crane";
     tincr.inputs.fenix.follows = "hosthog/fenix";
 
-    tribuchet.url = "github:Mic92/tribuchet";
-    tribuchet.inputs.crane.follows = "crane";
-    tribuchet.inputs.nixpkgs.follows = "nixpkgs";
-    tribuchet.inputs.treefmt-nix.follows = "treefmt-nix";
+    flakelet.url = "github:Mic92/flakelet";
+    flakelet.inputs.nixpkgs.follows = "nixpkgs";
 
     srvos.url = "github:numtide/srvos";
     # actually not used when using the modules but than nothing ever will try to fetch this nixpkgs variant

--- a/modules/tribuchet/default.nix
+++ b/modules/tribuchet/default.nix
@@ -1,5 +1,4 @@
-# tribuchet build worker for the hub on eve. Serves this host's native
-# system; max-jobs defaults to the host's core count in tribuchet.
+# tribuchet build worker for the hub on eve
 {
   config,
   pkgs,
@@ -7,24 +6,30 @@
   ...
 }:
 {
-  imports = [ inputs.tribuchet.nixosModules.default ];
+  imports = [ inputs.flakelet.nixosModules.flakelet ];
 
-  # worker.key is signed by the CA generated on eve (clan vars generator
-  # "tribuchet" in the dotfiles repo); ca.crt and worker.crt are public
-  # and committed next to this module. The default sopsFile is the
-  # importing host's hosts/<host>.yml.
+  # signed by the CA from eve's clan vars generator "tribuchet"
   sops.secrets."tribuchet-worker-key" = { };
 
-  services.tribuchet-worker = {
+  # the worker imports build inputs through the nix-daemon unsigned
+  nix.settings.trusted-users = [ "tribuchet" ];
+
+  services.flakelets = {
     enable = true;
-    # delivered via systemd LoadCredential; the sops secret stays root-owned
-    keyFile = config.sops.secrets."tribuchet-worker-key".path;
-    settings = {
-      hub = "https://eve.thalheim.io:7437";
-      systems = [ pkgs.stdenv.hostPlatform.system ];
-      max-log-size = 67108864;
-      ca-cert = ./ca.crt;
-      cert = ./worker.crt;
+    services.tribuchet-worker = {
+      flake = "github:Mic92/tribuchet";
+      output = "flakelets.worker";
+      autoUpdate.enable = true;
+      settings = {
+        keyFile = config.sops.secrets."tribuchet-worker-key".path;
+        worker = {
+          hub = "https://eve.thalheim.io:7437";
+          systems = [ pkgs.stdenv.hostPlatform.system ];
+          max-log-size = 67108864;
+          ca-cert = "${./ca.crt}";
+          cert = "${./worker.crt}";
+        };
+      };
     };
   };
 }


### PR DESCRIPTION
Worker updates land on eliza/jamie via flakelet's auto-update instead of waiting for a full host rebuild, matching how the hub on eve is managed. The tribuchet flake input is no longer needed since the package is built on the machine from the flake reference.