### PR TITLE
vllm: switch to Qwen3.8-27B-FP8 with full 262144 context

### DIFF
--- a/modules/vllm.nix
+++ b/modules/vllm.nix
@@ -1,29 +1,40 @@
 {
-  # Serve Qwen3-30B-A3B-Instruct-2507 via vLLM's OpenAI-compatible API.
+  # Serve Qwen3.8-27B via vLLM's OpenAI-compatible API.
   # Runs as a Docker container because nixpkgs has no maintained CUDA-enabled
-  # vLLM package. FP8 checkpoint is used to fit the 48GB A40 (weight-only
-  # FP8-Marlin kernels on Ampere).
+  # vLLM package. FP8 checkpoint (~28GiB) is used to fit the 48GB A40
+  # (weight-only FP8-Marlin kernels on Ampere). Only 16 of 64 layers keep a
+  # KV cache (hybrid attention), so with fp8 KV the full 262144 context fits.
+  # Flags follow https://recipes.vllm.ai/Qwen/Qwen3.8-27B
   virtualisation.oci-containers = {
     backend = "docker";
     containers.vllm = {
-      image = "vllm/vllm-openai:v0.26.0-cu129-ubuntu2404";
+      image = "vllm/vllm-openai:v0.28.0-cu129-ubuntu2404";
       cmd = [
         "--model"
-        "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8"
+        "Qwen/Qwen3.8-27B-FP8"
         "--served-model-name"
-        "qwen3-30b-a3b-instruct"
+        "qwen3.8-27b"
+        # Text-only serving; skips loading the vision tower to leave VRAM for KV.
+        "--language-model-only"
         "--host"
         "::"
         "--port"
         "8000"
         "--max-model-len"
-        "98304"
+        "262144"
+        "--kv-cache-dtype"
+        "fp8"
         "--gpu-memory-utilization"
         "0.94"
+        "--reasoning-parser"
+        "qwen3"
         # Required for OpenAI-style tool/function calling (e.g. coding agents)
         "--enable-auto-tool-choice"
         "--tool-call-parser"
-        "hermes"
+        "qwen3_coder"
+        # Built-in MTP draft head; dense 27B decode is bandwidth-bound on the A40.
+        "--speculative-config"
+        ''{"method":"mtp","num_speculative_tokens":3}''
       ];
       volumes = [ "/var/lib/vllm/huggingface:/root/.cache/huggingface" ];
       extraOptions = [


### PR DESCRIPTION

Qwen3.8-27B supersedes Qwen3-30B-A3B and, thanks to hybrid attention
(KV cache on only 16/64 layers), fits the full 262144 context on the
48GB A40 with fp8 weights and fp8 KV cache. The model needs a newer vLLM
than 0.26.0, so bump the image to 0.28.0. Enable the in-checkpoint MTP
draft head since dense decode is bandwidth-bound on Ampere, and skip
the vision tower as we only serve text.
