### PR TITLE
doctor: forward {niks3,cache}.dos.cit.tum.de to nixcache

### DIFF
--- a/hosts/doctor.nix
+++ b/hosts/doctor.nix
@@ -3,6 +3,7 @@
     ../modules/nspawn-container.nix
     ../modules/borgbackup-repos
     ../modules/buildbot/reverse-proxy.nix
+    ../modules/niks3/forward.nix
     ../modules/monitoring/prometheus
     ../modules/monitoring/loki.nix
     ../modules/monitoring/telegraf.nix

--- a/modules/niks3/forward.nix
+++ b/modules/niks3/forward.nix
@@ -1,0 +1,25 @@
+# Stopgap: {niks3,cache}.dos.cit.tum.de DNS currently resolves to dosvm5
+# (doctor) instead of nixcache. Proxy through until the records are fixed.
+{ config, ... }:
+let
+  hosts = config.networking.doctorwho.hosts;
+  forward = {
+    enableACME = true;
+    forceSSL = true;
+    locations."/" = {
+      proxyPass = "https://${hosts.nixcache.ipv4}";
+      recommendedProxySettings = true;
+      extraConfig = ''
+        proxy_ssl_server_name on;
+        proxy_ssl_name $host;
+        client_max_body_size 0;
+        proxy_request_buffering off;
+        proxy_buffering off;
+      '';
+    };
+  };
+in
+{
+  services.nginx.virtualHosts."niks3.dos.cit.tum.de" = forward;
+  services.nginx.virtualHosts."cache.dos.cit.tum.de" = forward;
+}


### PR DESCRIPTION
The DNS records were moved off doctorold but point at dosvm5 (doctor)
instead of nixcache, so clients get the alertmanager cert and a 403.
Proxy through doctor until the records are corrected.
