### PR TITLE
niks3: encrypt secrets for graham again

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -917,6 +917,7 @@ creation_rules:
   - key_groups:
       - age:
           - age1ssg0kfcc2g75rtcfsg235evaya5vuazh985nu39tyemwkl28t97qd8jaap
+          - age1qnz850jesp6l4968vqdp40mqenmtx3czhy5l8hsz4kym3aj8c56srs5dkk
           - age17n64ahe3wesh8l8lj0zylf4nljdmqn28hvqns2g7hgm9mdkhlsvsjuvkxz
           - age1nnm255ah9wa4gpsaq0v023a75lnmlcxszt9lc6az3mtwzxgrucfq45rp7h
           - age1r8v7gf5wxmggsecapn2ptm3q6gjpyquw2fm3dwhr59jpmyjvzcfqd03zcd

--- a/modules/niks3/secrets.yml
+++ b/modules/niks3/secrets.yml
@@ -6,191 +6,200 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBteDFhSGVRWTZXMGZUcTBV
-            ZnZ2VEtjdUlZSUU2WEZNMks5eE56ZVpMcEhrCnU2L25haE5zZUUyeHZjbEpaYUZU
-            dFpESHQyVjVDYW1xUXg4QUJsK2xFS2cKLS0tIEdIOFhMSStZMWtsV05LNlhzVWJQ
-            QnJscGdzTVhBd056Tk1GYnZNeTBsVzQK+lQ+i6bXbHroqfZPkoyUjJOdZeD2Q54i
-            EfyD+3p08g4k0jUe/Xa+ezt+8KWdWY7qfBYy5Xdzb2yVj9JdLo5cTg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLS0pQU0QvNEIrVW5zbWhm
+            MkJGUW9xNFE0cklWRERMeWxTd0MwZXU5dVZ3CjhHQ0sxNXZBa2RLY2h4blBONW9H
+            aGJ6YnNISVQ2OExhU3hjc1NYYjd4dncKLS0tIExBNWtac3FhQVNyWTZMRjB4WmF3
+            SGYwS2VCSVkzbGd4UmoxMlFzNlhWZzAKT5cMzDQnUZh2EeaDe/D6OlM3/D4TvG/+
+            /1mp2VB8KwzrM4AgJsh902ZKj+ZHnCxyRTO2Yj788EpCOrQ/yHWDoA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ssg0kfcc2g75rtcfsg235evaya5vuazh985nu39tyemwkl28t97qd8jaap
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNVG9kNTF4OG9QV042UlQ4
-            OW9TQ3hLeWJ3NFZYc1FCNlNXalNtTnppQVVZClptYU9TQmduaTZYM0FmRG1nOXBk
-            bkpJb2x2WDJwTHQyM2pzMWxKR1pvRVEKLS0tIDFjaE9vRmN0cDhPbnI3d1YwdFls
-            NERRNjRDWGNBS1pXM21BZXRSWFFpZVEKjVPw2iQGMvNtY5OiZq4vLD2bG/MlAl7h
-            74Nb9Lb2603QXcNbxAkNHXEdlbfsPNRbFscMjFk0k/+qwaTfoHq9pA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBndDM1WFJ2eG5URjArVWNY
+            UXU0aUlIUVd3dERuR05IMXZVRFNWdlpRWkZNCk45dWsxUjZpQ3Z0ZlZHQWg3T0wz
+            OEJYK2N6OFZkTEg2RVlMK2VPNzRRTE0KLS0tIEM2TFZVOWFLVHJLWEMvYkZwK3hr
+            SlhNK3oyZ1dSczNqeTh5aUQwNm5MM3MK089EmnfPfNp6xZgcayWCWY8+4Z/t/rs1
+            HMUeB2GfM/2MQbQrI5VoOa/Ei4vrMo7bWuAngGzu1NCyyLT9MK3xUA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1qnz850jesp6l4968vqdp40mqenmtx3czhy5l8hsz4kym3aj8c56srs5dkk
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjMFpqV01Iemd5YmJJczlX
+            TloxRHNvVkJpMWtPbjAzT2draFdqVmZxckRNClNBdy94RURRWnkxS21UdlNsbGdM
+            OU5JNytPblNxT0ZmMVRWWUZEckhrWWsKLS0tIDhyR0VuRi8rRFJ0WERkQ29FeXNV
+            ZWxCY1hCUDJiK0ppTlMrNGlNMFMyRXMKLJ25Z08ay5fcXXWUkAUMqXPGPqolSwbO
+            7LqPkTYwk0eyjW4laKo/3qk6FK4m7CWK8dA4A6K5YmOUxKpd2l/MAg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age17n64ahe3wesh8l8lj0zylf4nljdmqn28hvqns2g7hgm9mdkhlsvsjuvkxz
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwRHh2QXVuNXBqeFFnaktU
-            MG5RQituTG5VR2Rnb3NYWnQzekRKcEVLOUc4ClVEajRlYlE3WEhMdnVKanRMdUJR
-            N3ZMMUprYkY4d0JzSURJV2NNaHlrR00KLS0tIDB6VHVMWDVXYldERFZoOTRyMldG
-            QkJjSHJudStEMXFwRThwVmJXQUFzQ0EK/3slOmbRotnCvC7i/UZfO2QbG7pPCIl1
-            BBZL/vSrbspmj58495d9xtYfPZKFE4yWInp3og8g0Nt1s5fWXMiAdQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWWWlkdlRZSWUzelJUMmFi
+            Z3dxcHRlRHRNMzAwNzlZTWFqUUc1Sk5LdjJ3ClNyZktQTzl0R3BJZzRPN0hUS1Jv
+            KzZyREUvbnBmbjQyeUlEdURSUStVK1EKLS0tIGN4SFhFek1WdjVzNC9ER0I4MXI0
+            cTFXWEJVRnNKNit5a29hSld0bEhCWVkKhN8M9IznzsCm3bftungVvcHz9HujAhGY
+            ctJjLu6BkQbn2QjBVnKWbdeUFzpOmrhw5r/k8jkf1x3gfhvsB/S3oQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1nnm255ah9wa4gpsaq0v023a75lnmlcxszt9lc6az3mtwzxgrucfq45rp7h
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsczI2RmpQYnNyZkZQck8z
-            RWNXRUpUcVM3emNONXNZTHFxZnJjOU5YazFZCnMyTEl6SldPOVd5Y3U2UUhsaEdn
-            NjJBUklrSTVQV2JrZWRxWGFQVTdBUlEKLS0tIElUaFFqYlN0bTM0Y2xZRURuRlh5
-            cm5zSDhXWjZES2lIeWxoRC9vSG9rb0EKlVKm116S/0lg44r6PIOj9ia+BKmDDbAB
-            lXfJGtV1RQrnshIDAixv6OH+4cwmgfiOEo8yCzUf6Ji0V9t/GwojQg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLbmpkOUxSOWJSRXhoVVkr
+            MG45S2FRSXFhVUVFdWtWNDNDZzYybVUvY25vCmY0SUZURTJzNVhCMnNKVEJFQ0cy
+            QkxLQ2N1d09ucXhtQld1UE5HSFR5RzgKLS0tIGZibDRwRHdCMFQwUTF6TElZMktL
+            R1BtNTdYU082cXRsTkNjOXczUFZXQ1kKT3DprVDg4s/6+oucLgop4w5ZnLVlXhwn
+            xg68sBkW3nXE8tSRyUWvhVOqR85NVhSc/Wtoo3DfSeZLirYyswsAjA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1r8v7gf5wxmggsecapn2ptm3q6gjpyquw2fm3dwhr59jpmyjvzcfqd03zcd
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRa0oxNWVaTEhLbHpkMEdj
-            VTZmcVhtem0xYWQ5bS9JUjVkZFdKNy8raERjCmFmbDJ4VGM5QmNqajR6Y1NkckE4
-            UXBkTFpRd3ZvOW5zeGxqc054VVpWMWcKLS0tIFJuVHUvMDVJSDFRVmpWK0VNQ2Rr
-            UVkxcEZ6YXUwc2RNMS9BUjFHMkx3UzAK+33IJfzs2+YuY44qYK67dzSKizRlDUo4
-            p/YT541ZAuHryNvyL+iZQSEAyhiopRuDT0/SsOX/BVeUtzChevcpOQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKUW1mSmpRNlMzRWZEa1NF
+            M1BDdElobE11SW03Z1RTRkIrZm5TVjg0cEVjCmRWbnZsUW9ONUxnbHR6VHJyWkg4
+            OSt2bmVLY2Z2d1hZMUE2WXNZZ0lZaTgKLS0tIDlYdlVYYXMrQzRxV2w2ZnBGOU9G
+            NHFNSFZlNFcwSDNKcGwvVnFtQzRYOTAKzktD+GdFELIyqP54m8Lv4FdEhffyX4rA
+            xXbqJx99Sc6si6jilGeI8EKM+OzrKfCKFk5f++JS7rJZmVIP2hSLNA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1et533lu2xqnxl5k332f2q57hqxu8j7j4lrzcannqynfmf9xh2azqfzheu4
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2Y2VBdGs1TStmaFk3dzkr
-            WTJVNFc0VzRFdXM2RVNaSjdtVlpXWGxkeUdNCjNzTVFkM0hJb25IREc5cHhZSWNK
-            eFNTWFNra0toQjhBNEVLekJIdFhKcU0KLS0tIHlLV09rcnhEdWtmd09FOW4xR3Jk
-            VHV3MG9DR0xaR1lCa1pLWVJzeGlqVzQK7lsr4NgXrYwbV1T1FRfANYdWISFbBhWa
-            WHnRLUnlYBVIpjLqMtLyZqpmdbatlrrmkJRtdcjE5YARr4GIaC/tgw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLQW00Ryt2aytoR0Y3OTlx
+            MjVZZjAwR2Q4RmpaWitjTDRGNFM2NlVPejNrCmVYaHMrNlR0cnVUWnJZc3FiUUhM
+            TzRucVh2WE5JaFVwK2t4eTJVelBwT1EKLS0tIGpRbTVra0dPcytJampvOVEwMXNt
+            T1ZIcVF4OCtBVWE0bnZNRUdnNGVpT0kKJ5l41mZF85D5zfRFHfUntXSB9N5ayVoQ
+            gWyWOble3KwtiGkqVDGMs5J0G52CETwCFaIHaQBp00nlkq08WfRL/A==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1wtek04smdkn5h7nz5x5dtcjpd4l0srxjru6cpk37wgf0aurnc3sspre2e8
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMThUNjVvcmd1cWNVankw
-            Smt0cFJUcUhqWlFlNnBXTDJ4ZEZZNWoyUmd3CjdQS0J1cXNyeXNxNnBMQm91elgv
-            RUdsOU80S2w2eFkxU1lQbE1PYWhwRUEKLS0tIGZXNXBya2c5TXlRZWxKS2Rvdk0w
-            RmRaSWtsZXMreUVtT2hJS05TWUhDZmcKRI7AnS/27OQwFtZiW9jLePSqXz/04Co6
-            BUX7BQYEv/99CQuns6V5A8h9S3zqIhlRh9gGUqTsdoHbJTlzhPbkTA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTcVRMQUdmQ2VZVHp2WEdz
+            VTJJSThHZDlGUWpZaXhDZEd5dVh6YWt4S0VnCmdqditLcXVEZWdXanRhc09rSE8y
+            RUNwQlRvamlJeXdjb3AvaFhrbmV4MDQKLS0tIG02bFhqOENRWTBRcDlFYnV1ZXZD
+            YXBZQjNMUzBnMlNnNlpUVzNuMlc4cU0K3svKMIjy138PsPREJ8L+G9VXid5XKBq3
+            eYQMANhQCsuy/yEWeJk+bWAsASWDuY9s8LwZ5v4y1jr3dviDszDD7A==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1grsm7z79fd2jyzqxdarwkastyyhghrjcadj5s06akgca704ztcpshx5qcv
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5Y3YyMVdzeHdlN1k1b3Y5
-            Rjdjc1NZS2tFZk55amxDM2FadHJEekRON1Q4CkJHcVlnbjdWdkVoS2hXSXpJQjR5
-            NTRTb05adXpjbEtub0RTWjNXblk5ZzQKLS0tIDI5V3V3K3BncndpSzJUS0ZvdFll
-            ZDlUVzFTN2lNNnRUSzViek1Bc0dIcGcKbh3m/gyoX46j2LQ6O74LDDDk0gnVJNO4
-            csSQq7fUIz26ZgPPLGyqnCAQ0fKXbX1PottB4utomeOTnCCzlMsPSg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6cVNOd3ZxT1lLdWRXRmFW
+            VWVianY2a3B5L0trVGtnck1vY1d4enVSSTNrCktYcG56ZGpOcnB1VVlTMTFDb2NK
+            eDhXa2ZTNUR5LzYxQlFxdmFMMzRRdGMKLS0tIG1BdVd5aEkxQ3hDd0UrRSs3bHN6
+            OHJvK3hnYjAvK3p4cTVucHJidXBJdEEKepf+1/ZbPjlR38SN3yHvCXqPPmM8PInM
+            XNFZFOgU0UszCh7IVHWn4LzS4yrjon2u5Y1Eer4/TV78Hcm14aJRQg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1tpftd5kz59gqahy9e0778wc06qhams6l29zj2n97khekd3ezwyyqthlpr0
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNR01JUTBFMFROd1NEdzFK
-            YU1jb3FQR1Y0UEpqbXhZeThnSGpmS2RrNVVZCk1oR2twQVZsdWtqeGxxV1RLYkZs
-            Z0VaZjM3Slg2RWZURWtDbEIrVVE0d00KLS0tIDRWTVJyV0tzYjltbllkSysxNUFI
-            Q0tmUnFKNTkvY2RFOFdVd21FOXBqVEkKN19m/0q9KcOdwGeEEIKj7rAWaq/YmW4b
-            hEi1/9DjIb6ykEuuIJkQSAKh6HNoIatUCShsjoVhXljOvzGC2TO8cw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYRzQxMGk1SkVLNjVpZjc0
+            ZDk4SnY5U3NpRG41MkUwL2hkWjFIUUdKNWdFCnI1R2xYd0pLdndrQnlxNWh2Q1lY
+            QWY3VEg5ZGpFaDJucysyQ252am5ETncKLS0tIHdCOVpEVEZUOEs0aGIydmFDNDFY
+            dEtJa09tZHB5NVhUZDNqL2JobTZFWGMKXJ38XvLTdJGIRC7AvHTZHCryYBd2o1GQ
+            j5hJb/811paolEfeNevaDnTmKepn6cLiAy4EGETB0JZDzAM/pKXesA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1alt8n4tq5pyn7atrtqmtkhqn9p8aeanxd55pf07ehqp3mhkdfp6qmj2fpd
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTSjBsejdWTjkyY3FoaDZM
-            UGcxWkxoM0lTTlV2ZG1FcUhJR2hpdElxQkFzCmx1bDJ6VlpJbSsxS1o2YkR1VEZ5
-            ZWZ0NVJSVW9Wb09RU0tNMnFseStlYlkKLS0tIGR1cHNEank1SkNPT1BHdXZNK2Rk
-            MnVxY2IrdHZMcm9RT1JWK2ZPTHJFYjAKoagaBUh3cAYVQbMkgINFsFJzXUsnlOG4
-            GI9R3O/FJP40rOFZMHVjO450ktqta2DKjgYQwxiH+SaegPuHrLlkEQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJU3JLRERyd0NGWUhzdEdE
+            c012V0VCUFZlTWo3OXNUQmVUVFNnZkFOcldrCkhJcHdscXB2WWt4aHVLZ284SE9j
+            VytyVUYxblJZUVQ4dWlHTm9HMjBpYkkKLS0tIERPYVlQMkZSZUoreCt2YmRpdy80
+            NzZwd3pXZVRCNXBzSVFlSWNNUXBSS0EKihPR0zTullHci6v/b5TeCOXb4pnprM1p
+            dRVtBiZvoO3P+TZzUSywARKQ26ounBOpqd57bFCwiakPr5GUJyXkGg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age17ve9wnwazsmp2xgvsp27u7clywqwwqynsslyyxa4k0hu8mznf5qq2vmp2c
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUeExSZS9vdnJLODJwa0t6
-            UkpIZmFlOFhrZVo2ck5NbDI2TmhXWGVSbkI0CnRlc1FpT3JuMnJOQmVZb3RldDBB
-            YVJ3d2dDSWQ4dGpVcTVDZEM3YVFGZ2MKLS0tIDBKUEorR2VGU2hiWkQ5ekN1cnd5
-            V0xNL0poS2Y5MWxERHM0Wld5T2Nid3MKUrhjtCGVqZAUr2ssx2SqV1bIX/vsyf7h
-            0xrZGG2Q+33Cfv8iz/wxexy582lh4H+sjsGRswu0yediLkD60oozZQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZTXpzMmZLSldlYTJGWE8r
+            MGlmemNXTzNZNUJVSzEwOU80OGtrNXRNNEd3CnVxaFJRU2I4U2ZCYlFRM1FmS0Fq
+            TGNaL2Y5bTdmZ3l5T1hLMUxBZW5kdmcKLS0tIEdyRUd2R0FuQ2pXdzVDaW9oZmNm
+            bDlOUWRHZGNuU2xEQkgvSy9aZ3RPVncKVIfSZHMTnxcn+BTqZZH9+oZ+/DX6c7wc
+            I+PFkTBzH7e1VMOw7DuAPihpe5UlDszuKliE3Eq4TXzBadiNMECXaw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1mgk6cnl7dmzu6xqs4k7e5epjjg4ygjtjzy9fxqwnw6u8ygtlvpns79zgdk
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4bXZrRzNrQW1NelBXWU9h
-            ejVnNStIVkxGMUR3VUlqSzdjN1o3UVhiVEJZCjVhTGJWZXAwcTZZVkE1eVdQeUo3
-            TG5kZ0QxcEtVVVRjeHNRamFrYVlyZUkKLS0tIC9Nam9sdXpNOTRkMW81L2dPSlJq
-            RHUrMlZVWGFCVHAyanlDd2s0Zk54VkkKtt72TdAZ9YCRVaJG3lxi892FqpFQoXSH
-            tZL7zr71ECWNx2SaI8ykByC1X8i9RGm+7DLwmK4Dba7SmiP5UQBf5A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4bjc0SExNL0MxVTI5L2Z2
+            UHN1UkFYeUdRbU0yT05aY1RUclZiV0k4RFZvCjYxOE9sK3Q5bnBRekxwUjBzcnZN
+            cSs5UXVDdWR1cTI3MnZSLzVwT1lzMVUKLS0tIGpjbGt6TG13OWVQYlBlNHhoNXkr
+            RXpNY2JpSmNiY2RYMHJMcWxPOGI1WXcKcNUaL8qCp1blaiqetAevRey3ICo8/l15
+            3b4QOVK8aoOflE1zStbbhP9oGW6laU96OjcrLIqVqP+K674Oa/xB5Q==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ku5zg6vzgprhavukpj0f8zjsfe2cxl0g4hceljf62hld8t8fguyqp4qtw7
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6RVJLOVptRlY1RTJhL3BD
-            UWdMb2N4dWh0ZS9Sc3lzNlJXY0dvK0hidTBzCnZLNnpjbHk0ZzFEeWYzQzR5azBK
-            OEp3NGF4TWJYOXNLU1VHWGduTldoWW8KLS0tIEpTc25Yc2JqMXB2U3preGZvU2lS
-            TG4zdDJNYVkzR1AzYXl3ZHU0bStwQ0UKjRwGHykCcU9sYfvH8bnzunCpLL2lIEDs
-            nXp6CL/BWEA9yDqplbnC/341F1VhpVI+nzOi5lXOol+Cif1MzE7uHQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4NFE3WDdwam4rcmtTbDBu
+            OC9JaVRNVkUyb2hXVjdoZFc0K1o4YkZ2M0VNCk8xYWhnbGlNVzk5K1huMWlLa1ND
+            azZOUk84T3VnTmVBb1NxYUVuZUlqc2cKLS0tIFQ0cDlGd2taYUt4ejVQd0oyR2pn
+            b3VnNUpxaUtHRUUyelNxSkNyYnpjRE0KN8KVzw8HKIyzNwhuI3SdlV/mUPIMMMzo
+            Iic74UmKQE2lGONqe+E93b62x2HA2eDPXaDkH+7j2sQLyzDjUIQu1Q==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1qqe0k440aueynmdtyqxrmyhfgw8cs7a3u3xptaazrgvven5gqsmswf3dnf
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQb0dPV0JEbjhsQzZiTTRS
-            S3JUd3AxeDFhZUR1cUhrdDRqMHI1ZS84bUMwClVBM1VmS05iTGQrTU5zbXpmRCtZ
-            Ym1zbVNBeVZxMVFMQ21lK3pMQ1hTanMKLS0tIGhKYjVyeStzQ1dhM05jTFhjUnNj
-            Ky9NNlgwMFNqeWZpdVB6UDhmNE9aK0EKol/7JbpbEcG6Xg+KQJt+FjnWiff/lLlW
-            DHaHtDnvOooSvZ8O0iu+JjPj0xs1QRCdAovb/A5rN+Oj8cRsKuJMig==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHRkIvSjVOMy9LSTZ0L1lW
+            MnB0dS90MGpsbjBBYSswdzRFK2NwQUJWWEVRCkExRFo2WExsdStycjBwQXJhMFlh
+            YURpL1ZBUkNJMjBNOEExeHd1emFMZ0EKLS0tIDZDb2xiOEFhK0kxSkZWSDBTRC9Y
+            STZmZlB2RFFpcmtaUTA5aTEyekUyVncKu8FKTTDifs4LLmPrT9ySMDVG+bcLxPvi
+            bpQsPkp/ZPSnEihuBq+fHwpq74ixOSjVIksZ59rlztEGi2WAf/CXMw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1vetu6glcp8md6uqv05jvyyqej47wumswxzjyaadnmuxh89at6sesrxcxzy
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBObDVLeEV6QUNZaG14Mkpw
-            bDVheksvNWRzV0orcWRydm0xeVAyVzl6Y2lNCmozVU5Wbjhjb3h6L01nR0diZDZZ
-            cS8zNFJKU2hFK1NOV2p1a1lpdmhwWEUKLS0tIG90dDArOCthU2x4SEhwM3JHWXI1
-            MXh0Ym96T3FxNnN4TGlLc2hYbUZnM3cK3nUt0Av69zKJRspTFES/ky2sLPhabPob
-            0ixEIjBJL9cZmpJ697kn+XdMaw7qZUosP4KdrNjvGEgDTV3TwSRWFA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyT3ArOXdRV2xlMHVKbW5J
+            NFloTkloRTRwUmtpOFZiTWRxU0tLNmE0MzNjClU4YTJIQ0VnTjZLaDh5S2lKZHhD
+            WjQzOHlSalFYRjBxZ0VjZGhlZTRaSEEKLS0tIFdjelMrcW10OWN5djJUamwxTVZO
+            Y1c5cHZ1d2NLM2Jxc25yV014UFVKNlUKS2UBAxe6XjC8R56gbvMZbdsriOBkXl38
+            dmepxmbCxN/hl718/Nrj3wVyviSDGqi8PVKMMffWn0a8aHZd7C/UOg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1z6phh2tdqf2cqq435n3gpd58a3zpn0k88zylqu23gxps2hgk8etspg9g30
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2OEY5WENJZnZBcGV0UzJt
-            d09OTzBsaS9sUjliYVB3R1B1TmY2NEJja3gwCmNMYTJqa3F2VGh6eVQ1Y0JrWkVm
-            akcwNVBzRWhwazdsbC9MZnB0S3ZydGMKLS0tIEdUbHorakZuaVUzYmE1R1IrQy85
-            QjkydHBubTBVSmpZUnd3WCtld2cyZXMKeSSejJqqqy9Fm7fbfM1PZnB+8njOP8Ra
-            Ar1RwguvB+eId1kN06FPq+fqxKJmojPLDqbYEfSj0ts9F0G0eB2NQQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFall5d3lkRGNyZUJrUGpD
+            M01mOTBvNm4rMW55RmZBZERJWko4VnUwekJFCktiTVVMR291ZVpRVTZOVnI5L0Ny
+            cDk5VmE1SVQvREZVNXBlLytlYzNEb2cKLS0tIGg3VTU5b0tjMUIwMkRTWnVIT2h6
+            K0EzamZ4bVJtU2hxKzFOSEhlY2NhbFkKprGShGIpepn2bi/yzAAkFjAQjO2P25Qy
+            e+Gi9MuC4sTSdyt/45w0Lsj2tvdcGw8OKjGUB7vyW2B5J2Rep5YhYg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age17yvfale9tfad8kscjl63kyxzy46vvjg5lvgkfkg924q4vdpxkczqcaj2vx
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3T3dSNG5HZEkrNHd1KzV3
-            MkE1a3V0bmV0Z3FiT3ovNGtPS0xRZTBRQVFRCk9BRXEySDZad0R3T2xtZHpoelFj
-            RFhqVUM3bHN0MkFKME11VnU0ZEF3VFEKLS0tIHI5TDVub3RncTJLVTh5SWYzSzJi
-            THZlYU9LdjJuTEZYYXJ0ZS9jUVZBZjgKM5fPFOaEBp2UTb+V9fZJsqlCeNa2/oS6
-            B4OZI0yq4qjBhDHpqtMfKTejN9MdNouHpvp+qSapYMfZdyUToN9Rfw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnS3RGVThTNFdXTnlJZFk3
+            R0lkQ2d6eFAyN1dkbG9nU1dheDlhUkZ1QkVBCmFoZmpVSVNGV0FyOGFmOFprK01i
+            TExjYTIvUTNkRDE0RDUzM1NLd0hCUzAKLS0tIERXZkJOOFh3RDhGSk1MOXlvVGRm
+            enVRZ2FHMnZySlo1WnFkS0Q1OWIvb3MKY8flf4FhL5AYTjdXqc6gHlvNutt0wU1l
+            IfW2Yf8jT5vdAKaNrhriMYKeV71Iz87kKDFFSwTdEjLiuMLrfWl1/Q==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1qt20th9n7v0g9tdkhdvp4ztndvnet0nmv303sc68e38s32q965ysl46ns0
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWY1F6UUlSV09UbDJUeUxY
-            dzJ0K0h4aVhkUHliNHlKdnNIbVNwblQ2a2s4ClUvcmVJYi9DUjNUOE1VSXJPTkRM
-            R2R6UzVGWHkrY2ZRQnZCSE0rVDNLdE0KLS0tIFU5b2xZejBwOTlCMWxUTWl4Ui9s
-            TkVyR2ZsT2lLQzcvTWZuc3BuQWlzRWsKRqajL/vb8dG7oaBI7CSuyuZ1jaEc4jKP
-            skwSUVYfXX2IcWk8CA4grlqEgf4DxOf1/IFjrC3s8ii0QwnbnmHcrw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGbVozQ0oxMTlnc0xYejN1
+            KzVublNxbk0rY3prOXFzU1hsQXJnb2owZXg0CnV3cWk3L2d4a2lETGFrV1pLaVdw
+            cld1eWlQZHRSQmU5VG9XWWdCNkpWaTgKLS0tIHMvMXRhVFNIbWZjYW0yQnZ2OEdP
+            OEQ5TERrVkdELzRZcEpZYldCcG9XbGsKxf6iKtNCd/1lW9wI3X4SD5tTch5CBmPO
+            JMP69TzL47BV/rqsgoSfPkZkQajbAPP28kWUyVAAiORb628Qd8p5Ww==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1k4rx2m3mkd7n3ddtvdyjt6kjeyl2vrtkxwj4pqn7x955f9m6gessega7q2
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBZ3l1bzYxcE0xeHhOL1dv
-            ZmNseXVhdy91UE9aa3N6TVNqandtNFNaOFNJCk1CMm5UcktDczYraHV0K25FU3Ny
-            TkozV1EzZGppa0ovL1YyZW9OOWZoTDgKLS0tIEEzdzhhUTBqdTFwUndWZzNUYlVS
-            Ti9wd3NmOUE3dE5vQTVPQUJXNXpUTE0K6VS2FGcLcKqiTHgQTN0BzVeCpcwIuGEV
-            FMTXUuUiVlh0EP0doQvuGocwmUNRg/kdZ4OKQ7CM2fxCqgAdPw8GGg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGT0RIWTEydE5uVEdneHU4
+            bU5adEwwRmpZMlE2bVo3Q1kra0l2bm41dm1VCjRYVXdaUVMyY3pkekpCcGdnb21z
+            WUxLeDVVUlBUa25NVXJjNVJrQzNNNFEKLS0tIGdhYW9rZ3dPYlRFQTZaQlF0dTdp
+            dFlwdlA2UngwaVdXRVBMZjN2RGo3NkkKfN9cII/6NtAmWP8lJpJfXXnDZrKq0lJ7
+            XYySbSYikegGP+1BTJ+xf+XVZFTqc/0iNHxf01jg2z6Y8AkGbBsEuw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age10504jga9jn7uwlhfx3wusq8ax0xqqxq2zj24r3enr2k6efvwp90qfv53kn
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQOHc3YjZQNTdDcVA2R0h1
-            K2VhVkhTc2lrVDhFNjlkVFA3UlVZMDdaN3pzCkJORHRodmQxSjFGbTROMmpROVRC
-            TWxZbmI1Rm9kaEd3WG45RWxGV2lRZjQKLS0tIGZDKzV1UVFDTk9IemN0L0YzeHZo
-            bVE4NHBLNVZiQ2U3MUZKNzNJejhEZmMK85POHaMAFn6xt25frLlF+izCVdx5cauQ
-            QMIRMYKA4SWWe/xxFj23vXfJ+ZytFEGj8jNYrxrgiEYNd28c1Ot1kg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0Wmo5YkdrV2ZMRkYrRFFu
+            SWxRRkhOSXJQeld2WWgrdkFxOUZLZGRYSERzCkdabGFUbkI5M2dHUVR6RmFXUVl5
+            VSt2Z0JtcWlBRGVsc1R2eCtjUElxWTQKLS0tIElNeTg1UjN4UDhrL3ZTckhUUVdW
+            SDB1eStsTGo5OGE4SEpPWUNyNHhCYUUKXsJFRgsgMgZu1119APAa/fG82k85WtOk
+            LyrDgbWm5yLAeAtVnyUY8N6ZWsSh55SwddGPND18I00E46ZB0+uHLg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1dm3shdmfrlhzamy8nrzdqa08azc000x86207lmz2uu35fkfpnu7smg4t4r
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyNWJxeElxUGcvZkVNeEI2
-            ekZjMEhqSllQNUpIQjJEOUpwWkgrQTdqRm1JCkd2S3RQTzBmeDVodHZBejlzdGVy
-            aysyNUZRK3RwcG5lRWZOeEpuMDV1bncKLS0tIEpVVGtMamlEZmhheE5pb3RGM2ov
-            TkFlUGJyV1RsNnh4WXR5VkhBRGwxSkUKXK2fnCpzAmPOy2IVza28Qf3wahvq+E/S
-            1cN6ApNUhrF3Jua/KfOKq6PkOEtzxjUWmxKtdr/pHI1sdirQOGwA2A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvVVNlV244YkZlaHB2cU1H
+            VG1ORDBEaUZPSjVYMTJGZzRLQWtBNFYzU0hvCjFyZmZLYldkM0pWQUk2WXN0Y1NE
+            S3ltQ3o2UHVzQ2JVdkVOMlR5UCt4b3MKLS0tIGtFekxpWVNNZUtzUE5oV3dTWTc2
+            TTB5L2NhUll1SmVGc1JVbmxpNnlHNGMKTB5xFlKClZCfkRcCbdqscOnTE3QqQyAb
+            CV2hOk7BGh9WS1DvsclDiUAoqdc/xUKaOE4ParR2QwTO+v7yDsP0Zw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1j7xfwakhq3zdl62gp33h8ptwx8dxzgwpls6jyk8a4tyu89hm84gs32yf30
     lastmodified: "2025-12-26T13:26:01Z"

--- a/sops.yaml.nix
+++ b/sops.yaml.nix
@@ -61,7 +61,8 @@ let
     builtins.mapAttrs (name: value: (map (x: keys.machines.${x}) value)) {
       "modules/nfs/secrets.yml$" = [ "mickey" "dan" ];
       "modules/k3s/secrets.yml$" = [ "astrid" "mickey" "dan" ];
-      "modules/niks3/secrets.yml$" = [ "nixcache" ];
+      # graham: nixbot pushes to niks3 with the api token
+      "modules/niks3/secrets.yml$" = [ "nixcache" "graham" ];
       "modules/monitoring/secrets.yml$" = [ "doctor" ];
 
       "modules/users/xrdp-passwords.yml$" = [


### PR DESCRIPTION
3c0458ed moved niks3 to the nixcache VM and dropped every other host
from modules/niks3/secrets.yml, but graham still runs nixbot, which
reads niks3-api-token from that file to push build results. Without
its key sops-install-secrets fails on graham with
"0 successful groups required, got 0".
