### PR TITLE
auto-upgrade: pauses carry an expiry date instead of enable = false

### DIFF
--- a/hosts/jamie.nix
+++ b/hosts/jamie.nix
@@ -33,8 +33,6 @@
 
   system.stateVersion = "23.05";
 
-  # Teofil (6f783a9e, 2026-09-02): no auto-reboot while veritas
-  # experiments run on jamie.
-  systemd.timers.auto-reboot.enable = false;
-  systemd.services.auto-reboot.enable = false;
+  # No kernel reboots during the veritas experiments (Teofil, 6f783a9e).
+  dse.autoReboot.pauseUntil = "2026-09-12";
 }

--- a/hosts/tegan.nix
+++ b/hosts/tegan.nix
@@ -48,7 +48,6 @@
       };
     };
   };
-  # temporarily disable auto-reboot until the ricochet eval has finished running
-  systemd.timers.auto-reboot.enable = false;
-  systemd.services.auto-reboot.enable = false;
+  # No kernel reboots during the ricochet eval (Ilya, 96f90ab2, off since 2026-05-29).
+  dse.autoReboot.pauseUntil = "2026-10-05";
 }

--- a/modules/auto-upgrade.nix
+++ b/modules/auto-upgrade.nix
@@ -1,72 +1,120 @@
 {
   config,
+  lib,
   pkgs,
   ...
 }:
-{
-  # Fetch and apply system updates from buildbot CI
-  # Adapted from: https://github.com/nix-community/infra/blob/master/modules/nixos/common/update.nix
-  systemd.services.auto-upgrade = {
-    restartIfChanged = false;
-    unitConfig.X-StopOnRemoval = false;
-    serviceConfig = {
-      Restart = "on-failure";
-      RestartSec = "30s";
-      Type = "oneshot";
+let
+  # "Temporarily" disabling these tends to stick for months. A pause
+  # therefore carries its own end date, checked when the unit runs, so it
+  # lapses without anyone remembering to send a PR.
+  pauseOption =
+    what:
+    lib.mkOption {
+      type = lib.types.nullOr (lib.types.strMatching "[0-9]{4}-[0-9]{2}-[0-9]{2}");
+      default = null;
+      example = "2026-10-01";
+      description = "Skip ${what} until this date (YYYY-MM-DD, exclusive). Leave a comment saying why.";
     };
-    path = [
-      config.nix.package
-      config.systemd.package
-      pkgs.coreutils
-      pkgs.curl
-    ];
-    # nixbot publishes under checks.<buildPlatform.system>, not the runtime arch.
-    script = ''
-      set -euo pipefail
-
-      hostname=$(uname -n)
-      p=$(curl -fsSL "https://buildbot.dse.in.tum.de/nix-outputs/github/TUM-DSE/doctor-cluster-config/master/checks.${pkgs.stdenv.buildPlatform.system}.nixos-$hostname")
-
-      if [[ "$(readlink /run/current-system)" == "$p" ]]; then
-        echo "Already at $p, nothing to do"
+  pausedUntil =
+    date:
+    lib.optionalString (date != null) ''
+      if [[ "$(date +%F)" < "${date}" ]]; then
+        echo "paused until ${date} by the host configuration, skipping"
         exit 0
       fi
-
-      echo "Updating to $p"
-      nix-store --option narinfo-cache-negative-ttl 0 --realise "$p"
-      nix-env --profile /nix/var/nix/profiles/system --set "$p"
-
-      /nix/var/nix/profiles/system/bin/switch-to-configuration switch
     '';
+in
+{
+  options.dse = {
+    autoUpgrade.pauseUntil = pauseOption "switching to the latest master build";
+    autoReboot.pauseUntil = pauseOption "the monthly reboot into a new kernel";
   };
 
-  systemd.timers.auto-upgrade = {
-    wantedBy = [ "timers.target" ];
-    timerConfig = {
-      OnBootSec = "5m";
-      OnUnitInactiveSec = "1d";
+  config = {
+    # Fetch and apply system updates from buildbot CI
+    # Adapted from: https://github.com/nix-community/infra/blob/master/modules/nixos/common/update.nix
+    systemd.services.auto-upgrade = {
+      restartIfChanged = false;
+      unitConfig.X-StopOnRemoval = false;
+      serviceConfig = {
+        Restart = "on-failure";
+        RestartSec = "30s";
+        Type = "oneshot";
+      };
+      path = [
+        config.nix.package
+        config.systemd.package
+        pkgs.coreutils
+        pkgs.curl
+      ];
+      # nixbot publishes under checks.<buildPlatform.system>, not the runtime arch.
+      script = ''
+        set -euo pipefail
+        ${pausedUntil config.dse.autoUpgrade.pauseUntil}
+        hostname=$(uname -n)
+        p=$(curl -fsSL "https://buildbot.dse.in.tum.de/nix-outputs/github/TUM-DSE/doctor-cluster-config/master/checks.${pkgs.stdenv.buildPlatform.system}.nixos-$hostname")
+
+        if [[ "$(readlink /run/current-system)" == "$p" ]]; then
+          echo "Already at $p, nothing to do"
+          exit 0
+        fi
+
+        echo "Updating to $p"
+        nix-store --option narinfo-cache-negative-ttl 0 --realise "$p"
+        nix-env --profile /nix/var/nix/profiles/system --set "$p"
+
+        /nix/var/nix/profiles/system/bin/switch-to-configuration switch
+      '';
     };
-  };
 
-  # Reboot on the last Saturday of each month if kernel changed
-  systemd.timers.auto-reboot.timerConfig.RandomizedDelaySec = 60 * 20;
+    systemd.timers.auto-upgrade = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "5m";
+        OnUnitInactiveSec = "1d";
+      };
+    };
 
-  systemd.services.auto-reboot = {
-    path = [
-      pkgs.systemd
-      pkgs.util-linux
-    ];
-    startAt = "Sat *-*~07/1"; # Last Saturday of the month
-    script = ''
-      booted="$(readlink /run/booted-system/{initrd,kernel,kernel-modules})"
-      built="$(readlink /nix/var/nix/profiles/system/{initrd,kernel,kernel-modules})"
-      if [ "''${booted}" = "''${built}" ]; then
-        echo "No kernel update... skipping reboot"
-      else
-        # reboot in 24 hours
-        msg=$(shutdown -r +${toString (60 * 24)} 2>&1)
-        echo "$msg" | wall
-      fi
-    '';
+    # Reboot on the last Saturday of each month if kernel changed
+    systemd.timers.auto-reboot.timerConfig.RandomizedDelaySec = 60 * 20;
+
+    systemd.services.auto-reboot = {
+      path = [
+        pkgs.coreutils
+        pkgs.systemd
+        pkgs.util-linux
+      ];
+      startAt = "Sat *-*~07/1"; # Last Saturday of the month
+      script = ''
+        ${pausedUntil config.dse.autoReboot.pauseUntil}
+        booted="$(readlink /run/booted-system/{initrd,kernel,kernel-modules})"
+        built="$(readlink /nix/var/nix/profiles/system/{initrd,kernel,kernel-modules})"
+        if [ "''${booted}" = "''${built}" ]; then
+          echo "No kernel update... skipping reboot"
+        else
+          # reboot in 24 hours
+          msg=$(shutdown -r +${toString (60 * 24)} 2>&1)
+          echo "$msg" | wall
+        fi
+      '';
+    };
+
+    assertions =
+      map
+        (u: {
+          message = "Do not disable ${u.unit}; set dse.${u.option}.pauseUntil = \"YYYY-MM-DD\" instead so it comes back by itself.";
+          assertion = config.systemd.services.${u.unit}.enable && config.systemd.timers.${u.unit}.enable;
+        })
+        [
+          {
+            unit = "auto-upgrade";
+            option = "autoUpgrade";
+          }
+          {
+            unit = "auto-reboot";
+            option = "autoReboot";
+          }
+        ];
   };
 }


### PR DESCRIPTION
"Temporarily" disabling auto-reboot/auto-upgrade keeps outliving the
experiment it was for: tegan since 2026-05-29, and jamie had it
resurrected by accident in 6f783a9e together with auto-upgrade, which
then let a stale checkout stay deployed unnoticed.

dse.autoUpgrade.pauseUntil / dse.autoReboot.pauseUntil take a date that
the unit checks at runtime, so the pause lapses by itself. Disabling the
units directly is now an assertion failure pointing at the option.

jamie: reboot paused one week (until 2026-09-12) for the native-GPU
window. tegan: until 2026-10-05, ask Ilya whether ricochet still needs it.
