### PR TITLE
flake.lock: bump flakelet-relay for agent job history

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788435810,
-        "narHash": "sha256-iMP8MG/0iycvrQ1z43IRvQJc7/HldhcS+sM2NKqmoqs=",
+        "lastModified": 1788605695,
+        "narHash": "sha256-Tgb4l+/oBwha17kTu6Gy4Cp2PZY+xixUaxNrvNN+xmw=",
         "owner": "Mic92",
         "repo": "flakelet-relay",
-        "rev": "524322d75971302890969b941b2cbfe165d8aac3",
+        "rev": "ac37b38606e842672f3f6c133489a31d4c6a1452",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The agents on eliza/jamie predate the dashboard work and do not report
their job table, so the relay UI shows them as never deployed/degraded.
