### PR TITLE
flake.lock: bump flakelet, flakelet-relay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -198,11 +198,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788312293,
-        "narHash": "sha256-khVhEomZZqhp0GL9RiPaOrp+shvbQvhMl2e0rklyreE=",
+        "lastModified": 1788616363,
+        "narHash": "sha256-lcpMW62WiOxSchER2pPe0+OnokQdNGR0jACh+enTr6E=",
         "owner": "Mic92",
         "repo": "flakelet",
-        "rev": "bb3df2b31287219c575cade0a10087d21fc2a285",
+        "rev": "5b1ea76c1c13271722ae2adfd039ccaf18f11e67",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788605695,
-        "narHash": "sha256-Tgb4l+/oBwha17kTu6Gy4Cp2PZY+xixUaxNrvNN+xmw=",
+        "lastModified": 1788616394,
+        "narHash": "sha256-wcbm0Pn9VMaS2ty79VomSKWJwEJTF17iPQNMkhfTItI=",
         "owner": "Mic92",
         "repo": "flakelet-relay",
-        "rev": "ac37b38606e842672f3f6c133489a31d4c6a1452",
+        "rev": "4cd0a0db6fc15d0637870544badb4d09ea895b57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Fixes the agent reconnect loop on jamie where 'flakelet status' over 768 template instances exceeded the relay hello timeout.