### PR TITLE
flake: bump nixpkgs for fluent-bit riscv64 SIMD fix

### DIFF
--- a/modules/fluent-bit.nix
+++ b/modules/fluent-bit.nix
@@ -31,6 +31,15 @@ in
 
   services.fluent-bit = {
     enable = config.users.withSops;
+    # FLB_SIMD=Auto compiles the whole binary with -march=rv64gcv_zba when the
+    # compiler accepts it. The SG2042 (milkv pioneer) is rv64imafdc without
+    # V/Zba and SIGILLs at startup.
+    package = if pkgs.stdenv.hostPlatform.isRiscV64 then
+      pkgs.fluent-bit.overrideAttrs (old: {
+        cmakeFlags = old.cmakeFlags ++ [ (lib.cmakeFeature "FLB_SIMD" "Off") ];
+      })
+    else
+      pkgs.fluent-bit;
     settings = {
       service = {
         flush = 1;


### PR DESCRIPTION
fluent-bit was built with -march=rv64gcv_zba (FLB_SIMD=Auto) and SIGILLed at startup on tegan. Fix lives in TUM-DSE/nixpkgs c6005a89cb6b, upstream: Mic92/nixpkgs fluent-bit-riscv-simd.