### PR TITLE
fluent bit nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -457,10 +457,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788590831,
-        "narHash": "sha256-X2Xi4kGri4lSUIgpvLV6ejlG0twqdzHjZpPd3u90jlg=",
+        "lastModified": 1788697523,
+        "narHash": "sha256-9BCIcqvGK6qeN4zmQ6/CqO4sl/TlbKDE+qwTSU2D/zQ=",
         "ref": "nixos-26.05-backports",
-        "rev": "1e4716f8d8db8f8596eae3d919211fde02f85806",
+        "rev": "1911ed70a327541ead4a8dbe7939b62e3a6a7502",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/TUM-DSE/nixpkgs.git"

--- a/modules/fluent-bit.nix
+++ b/modules/fluent-bit.nix
@@ -31,15 +31,6 @@ in
 
   services.fluent-bit = {
     enable = config.users.withSops;
-    # FLB_SIMD=Auto compiles the whole binary with -march=rv64gcv_zba when the
-    # compiler accepts it. The SG2042 (milkv pioneer) is rv64imafdc without
-    # V/Zba and SIGILLs at startup.
-    package = if pkgs.stdenv.hostPlatform.isRiscV64 then
-      pkgs.fluent-bit.overrideAttrs (old: {
-        cmakeFlags = old.cmakeFlags ++ [ (lib.cmakeFeature "FLB_SIMD" "Off") ];
-      })
-    else
-      pkgs.fluent-bit;
     settings = {
       service = {
         flush = 1;


### PR DESCRIPTION
- **flake: bump nixpkgs for fluent-bit riscv64 SIMD fix**
- **fluent-bit: drop local riscv64 SIMD override**
