### PR TITLE
river/christina: add leon's low-latency VM host setup

### DIFF
--- a/hosts/christina.nix
+++ b/hosts/christina.nix
@@ -1,17 +1,75 @@
+{ pkgs, ... }:
 {
   imports = [
     ../modules/hardware/supermicro-x12spw-tf.nix
     ../modules/nfs/client.nix
     ../modules/dpdk.nix
     ../modules/vfio/iommu-intel.nix
+    ../modules/lowlatency-vm-host.nix
     ../modules/monitoring/fpga-dashboard/switch-collector.nix
   ];
 
   boot.hugepages1GB.number = 8;
-  systemd.network.ignorePci = [ 
+  boot.hugepages2MB.number =
+    let
+      gb = 30;
+    in
+    gb * 1024 / 2;
+
+  systemd.network.ignorePci = [
     "0000:00:1c.0"
     "0000:00:1c.1"
   ];
+
+  boot.initrd.availableKernelModules = [ "nvme" ];
+
+  virtualisation.libvirtd = {
+    enable = true;
+    qemu.package = pkgs.qemu_full;
+  };
+  environment.systemPackages = [ pkgs.libvirt ];
+
+  networking.doctor-bridge.enable = true;
+
+  # eno1 is a direct low-latency link into VMs: bridge without STP/forward
+  # delay, no IP config, and libvirt-created lltap* left alone by networkd.
+  systemd.network.netdevs."04-lowlat-bridge" = {
+    netdevConfig = {
+      Name = "lowlat-bridge";
+      Kind = "bridge";
+    };
+    bridgeConfig = {
+      STP = false;
+      ForwardDelaySec = 0;
+      MulticastSnooping = false;
+    };
+  };
+
+  systemd.network.networks."04-lowlat-eno1" = {
+    matchConfig.Name = "eno1";
+    networkConfig = {
+      Bridge = "lowlat-bridge";
+      DHCP = "no";
+      LinkLocalAddressing = "no";
+      IPv6AcceptRA = false;
+    };
+    linkConfig.RequiredForOnline = "enslaved";
+  };
+
+  systemd.network.networks."04-lowlat-bridge" = {
+    matchConfig.Name = "lowlat-bridge";
+    networkConfig = {
+      DHCP = "no";
+      LinkLocalAddressing = "no";
+      IPv6AcceptRA = false;
+    };
+    linkConfig.RequiredForOnline = "no";
+  };
+
+  systemd.network.networks."04-lowlat-lltap" = {
+    matchConfig.Name = "lltap*";
+    linkConfig.Unmanaged = true;
+  };
 
   networking.hostName = "christina";
 

--- a/hosts/river.nix
+++ b/hosts/river.nix
@@ -4,7 +4,20 @@
     ../modules/nfs/client.nix
     ../modules/dpdk.nix
     ../modules/vfio/iommu-intel.nix
+    ../modules/lowlatency-vm-host.nix
   ];
+
+  # eno1 is the direct low-latency link to christina; keep networkd from
+  # putting addresses on it.
+  systemd.network.networks."04-lowlat-eno1" = {
+    matchConfig.Name = "eno1";
+    networkConfig = {
+      DHCP = "no";
+      LinkLocalAddressing = "no";
+      IPv6AcceptRA = false;
+    };
+    linkConfig.RequiredForOnline = "no";
+  };
 
   boot.hugepages1GB.number = 8;
   boot.hugepages2MB.number =

--- a/modules/lowlatency-vm-host.nix
+++ b/modules/lowlatency-vm-host.nix
@@ -1,0 +1,28 @@
+# Isolate cores 8-11 for latency-sensitive VM/DPDK work; housekeeping,
+# IRQs, kthreads and all systemd-spawned processes stay on 0-7.
+{
+  powerManagement.enable = true;
+  powerManagement.cpuFreqGovernor = "performance";
+
+  boot.kernelParams = [
+    "nosmt"
+    "isolcpus=8-11"
+    "nohz_full=8-11"
+    "rcu_nocbs=8-11"
+    "rcu_nocb_poll"
+    "irqaffinity=0-7"
+    "kthread_cpus=0-7"
+    "intel_idle.max_cstate=0"
+    "idle=poll"
+    "nowatchdog"
+    "tsc=reliable"
+    "skew_tick=1"
+    "audit=0"
+  ];
+
+  systemd.settings.Manager.CPUAffinity = "0-7";
+  systemd.user.extraConfig = ''
+    [Manager]
+    CPUAffinity=0-7
+  '';
+}


### PR DESCRIPTION
leon kept a hand-edited repo copy in /etc/nixos on river and christina and ran nixos-rebuild switch from it. That reverted both hosts to an old nixpkgs after every auto-upgrade. This brings his changes into the repo.

Shared CPU isolation lives in modules/lowlatency-vm-host.nix. Host files keep the network and libvirt bits.