### PR TITLE
bump srvos for dynamic-derivations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -543,11 +543,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786933611,
-        "narHash": "sha256-FhNVyQZuDvWOozJ1mNuFJ/LY62r3PtBC+kzQNzdi400=",
+        "lastModified": 1788804923,
+        "narHash": "sha256-qnNF4ltAqFgPIOk074quP83OxrxhPK4/iZFJ7IcqERE=",
         "owner": "numtide",
         "repo": "srvos",
-        "rev": "3fea6d6ca2b90b9e86b36b0dc23abc8f92cf5b9f",
+        "rev": "2301a6c070c37a405c789516c2df430e52feae36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Needed on the builders for pkgs-research, whose language ecosystem
fetchers are dynamic derivations.
